### PR TITLE
Fix link to messages in the PHP README

### DIFF
--- a/php/README.md
+++ b/php/README.md
@@ -1,6 +1,6 @@
 # Cucumber Messages
 
-This is a PHP implementation of the [Cucumber Messages protocol](https://github.com/cucumber/common/blob/main/messages/README.md)
+This is a PHP implementation of the [Cucumber Messages protocol](https://github.com/cucumber/messages)
 
 ## Requirements
 


### PR DESCRIPTION
This is an absolute link because it also shows up in the subrepo and on the Packagist page https://packagist.org/packages/cucumber/messages
