### PR TITLE
GHA config for PHP with fixed caching and testing for BC breaks

### DIFF
--- a/.github/workflows/test-php.yml
+++ b/.github/workflows/test-php.yml
@@ -12,24 +12,42 @@ on:
 jobs:
   test-php:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php: ['8.1']
+        composer-mode: ['low-deps', 'high-deps']
 
     steps:
       - uses: actions/checkout@v3
 
-      - name: Cache Composer dependencies
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "${{ matrix.php }}"
+
+      - name: Discover composer cache directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-dir)"
+        working-directory: php
+
+      - name: Cache composer
         uses: actions/cache@v3
         with:
-          path: /tmp/composer-cache
-          key: ubuntu-latest-${{ hashFiles('php/composer.lock') }}
+          path: "${{ steps.composer-cache.outputs.dir }}"
+          key: composer
 
-      - name: Set up PHP
-        uses: php-actions/composer@v6
-        with:
-          working_dir: php
+      - name: Install dependencies
+        working-directory: php
+        run: |
+          if [[ "${{ matrix.composer-mode }}" = "low-deps" ]]; then
+            composer update --prefer-lowest
+          else
+            composer update
+          fi
 
       - name: Run tests
+        working-directory: php
         run: |
           vendor/bin/php-cs-fixer --dry-run --diff fix
           vendor/bin/psalm --no-cache
           vendor/bin/phpunit
-        working-directory: php


### PR DESCRIPTION
Adds a matrix that installs the lowest-allowed versions of composer dependencies; this should detect any backwards compatibility breaks

Also fixes the composer caching (was pointing to wrong folder) and uses a slightly different 'set up PHP' action that is more widely used
