### PR TITLE
add name field to package.cjs.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Add `name` field to `package.cjs.json` ([#36](https://github.com/cucumber/messages/pull/36))
+
 ## [19.1.2] - 2022-06-22
 
 ### Fixed

--- a/javascript/package.cjs.json
+++ b/javascript/package.cjs.json
@@ -1,3 +1,4 @@
 {
+    "name": "@cucumber/messages",
     "type": "commonjs"
 }


### PR DESCRIPTION
### 🤔 What's changed?

add `name` field to `package.cjs.json`

### ⚡️ What's your motivation? 

Tools like api-extractor look for a name in the closest package file, so it should always be present. This is currently blocking a piece of work in cucumber-js.

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
