### PR TITLE
Fix perl release

### DIFF
--- a/perl/dist.ini
+++ b/perl/dist.ini
@@ -35,7 +35,7 @@ exclude_filename=VERSION
 
 [GatherFile]
 ; explicitly add unversioned files
-filename=CHANGELOG.md
+filename=../CHANGELOG.md
 
 [Hook::VersionProvider]
 . = my $v = `cat ./VERSION`; chomp( $v ); $v;


### PR DESCRIPTION
The `dist.ini` explicitly references the `CHANGELOG` file which isn't here, it's in the root.

I'm not sure how this worked in the monorepo, but changing the path to the file seems to fix it.

Ref #45 