### PR TITLE
Fix jar check script in GHA

### DIFF
--- a/.github/workflows/test-java.yml
+++ b/.github/workflows/test-java.yml
@@ -39,5 +39,9 @@ jobs:
       - run: mvn test
         working-directory: java
 
-      - run: ./scripts/check-jar.sh
+      - name: Check JAR
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get install -y xmlstarlet
+          ./scripts/check-jar.sh
         working-directory: java

--- a/java/scripts/check-jar.sh
+++ b/java/scripts/check-jar.sh
@@ -3,14 +3,14 @@
 # Verifies that the jar doesn't have any non-"io.cucumber" classes. This might happen
 # if some dependencies are shaded, but some are forgotten.
 #
-set -uf -o pipefail
+set -euf -o pipefail
 
 check_jar() {
   jar="$1"
   module_name=$(xmlstarlet sel -N pom="http://maven.apache.org/POM/4.0.0"  -t -m "//pom:project.Automatic-Module-Name" -v . pom.xml)
   module_path=$(echo $module_name | sed "s/\./\\\\\//g" | sed "s/-/\\\\\//g")
   echo "Checking contents of ${jar} to see if it matches pattern: ${module_path}"
-  unshaded_classes=$(unzip -l ${jar} | grep -e "\.class" | rev | cut -d' ' -f1 | rev | grep -v "^$module_path")
+  unshaded_classes=$(unzip -l ${jar} | grep -e "\.class" | rev | cut -d' ' -f1 | rev | grep -v "^$module_path" || echo "" )
   if [[ "${unshaded_classes}" != "" ]]; then
     echo "Some classes in ${jar} are not in the expected package matching pattern ${module_path}. Rename the classes or change the maven-shade-plugin configuration."
     echo


### PR DESCRIPTION
The `scripts/java/check-jar.sh` was being run for the Java workflows, but silently failing because of a missing dependency on `xmlstarlet`

- Restricts the check to the ubuntu builds
- Explicitly installs xmlstarlet via apt
- Adds the `-e` flag to the script so similar errors in subshells will cause the main script to exit appropriately

We could also install the dependency in the Mac and Windows runs, if it's necessary. Although maybe checking the JAR in one context is enough?