### PR TITLE
Improve the Maven caching in docker builds build

### DIFF
--- a/java/Dockerfile
+++ b/java/Dockerfile
@@ -4,7 +4,7 @@
 ARG MAVEN_VERSION=3.8
 ARG JAVA_VERSION=16
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-${JAVA_VERSION} AS java
-
+WORKDIR /cucumber
 
 # Dummy stage for generated code, overriden in main build
 FROM scratch AS schema-codegen
@@ -12,8 +12,9 @@ FROM scratch AS schema-codegen
 
 FROM java AS with-dependencies
 
-COPY --link pom.xml maven-versions-rules.xml .
-RUN mvn install
+COPY --link pom.xml .
+# verify loads additional dependencies without running the tests (they aren't copied in yet)
+RUN mvn dependency:go-offline verify
 
 
 FROM java AS tested
@@ -22,4 +23,4 @@ COPY --link . .
 COPY --link --from=with-dependencies /root/.m2 /root/.m2
 COPY --link --from=schema-codegen / src/generated/java/io/cucumber/messages/types
 
-RUN mvn test
+RUN mvn verify


### PR DESCRIPTION
### 🤔 What's changed?

Fixes the commands used to pre-populate the maven local repository. This was wrongly doing `mvn install` to prime the dependencies, but that does something quite different

### ⚡️ What's your motivation? 

We don't want to be running the tests during the 'install dependencies' phase

### ♻️ Anything particular you want feedback on?

`mvn verify` at the end still pulls in some new dependencies every time - how can we prevent this?
