### PR TITLE
java: Suppress warnings for missing javadoc

### DIFF
--- a/.github/workflows/test-java.yml
+++ b/.github/workflows/test-java.yml
@@ -61,3 +61,7 @@ jobs:
 
       - run: mvn test
         working-directory: java
+        
+      - run: mvn clean package javadoc:jar -DskipTests=true
+        working-directory: java
+        

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- [Java] Suppress warnings for missing javadoc ([#128](https://github.com/cucumber/messages/pull/128))
 
 ## [21.0.0] - 2022-12-17
 ### Added

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -112,6 +112,13 @@
                     <parameters>true</parameters>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <additionalJOption>-Xdoclint:all,-missing</additionalJOption>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/java/src/generated/java/io/cucumber/messages/types/Attachment.java
+++ b/java/src/generated/java/io/cucumber/messages/types/Attachment.java
@@ -70,9 +70,9 @@ public final class Attachment {
      * Content encoding is *not* determined by the media type, but rather by the type
      * of the object being attached:
      *
-     * - string => IDENTITY
-     * - byte array => BASE64
-     * - stream => BASE64
+     * - string: IDENTITY
+     * - byte array: BASE64
+     * - stream: BASE64
      */
     public AttachmentContentEncoding getContentEncoding() {
         return contentEncoding;

--- a/java/src/generated/java/io/cucumber/messages/types/Exception.java
+++ b/java/src/generated/java/io/cucumber/messages/types/Exception.java
@@ -35,7 +35,7 @@ public final class Exception {
     }
 
     /**
-      * The message of exception that caused this result. E.g. expected: <"a"> but was: <"b">
+      * The message of exception that caused this result. E.g. expected: "a" but was: "b"
      */
     public Optional<String> getMessage() {
         return Optional.ofNullable(message);

--- a/jsonschema/Attachment.json
+++ b/jsonschema/Attachment.json
@@ -14,7 +14,7 @@
       "type": "string"
     },
     "contentEncoding": {
-      "description": "*\n Whether to interpret `body` \"as-is\" (IDENTITY) or if it needs to be Base64-decoded (BASE64).\n\n Content encoding is *not* determined by the media type, but rather by the type\n of the object being attached:\n\n - string => IDENTITY\n - byte array => BASE64\n - stream => BASE64",
+      "description": "*\n Whether to interpret `body` \"as-is\" (IDENTITY) or if it needs to be Base64-decoded (BASE64).\n\n Content encoding is *not* determined by the media type, but rather by the type\n of the object being attached:\n\n - string: IDENTITY\n - byte array: BASE64\n - stream: BASE64",
       "enum": [
         "IDENTITY",
         "BASE64"

--- a/jsonschema/Exception.json
+++ b/jsonschema/Exception.json
@@ -13,7 +13,7 @@
     },
     "message": {
       "type": "string",
-      "description": "The message of exception that caused this result. E.g. expected: <\"a\"> but was: <\"b\">"
+      "description": "The message of exception that caused this result. E.g. expected: \"a\" but was: \"b\""
     }
   },
   "type": "object"

--- a/messages.md
+++ b/messages.md
@@ -49,8 +49,8 @@ will only have one of its fields set, which indicates the payload of the message
 
 | Field | Type | Required    | Description |
 | ----- | ---- | ----------- | ----------- |
+| `type` | string | yes | |
 | `message` | string | no | |
-| `type` | string | no | |
 
 ## GherkinDocument
 

--- a/perl/lib/Cucumber/Messages.pm
+++ b/perl/lib/Cucumber/Messages.pm
@@ -120,9 +120,9 @@ has body =>
  Content encoding is *not* determined by the media type, but rather by the type
  of the object being attached:
 
- - string => IDENTITY
- - byte array => BASE64
- - stream => BASE64
+ - string: IDENTITY
+ - byte array: BASE64
+ - stream: BASE64
 
 
 Available constants for valid values of this field:
@@ -571,7 +571,7 @@ has type =>
 
 =head4 message
 
-The message of exception that caused this result. E.g. expected: <"a"> but was: <"b">
+The message of exception that caused this result. E.g. expected: "a" but was: "b"
 
 =cut
 

--- a/php/src-generated/Attachment.php
+++ b/php/src-generated/Attachment.php
@@ -49,9 +49,9 @@ final class Attachment implements JsonSerializable
          * Content encoding is *not* determined by the media type, but rather by the type
          * of the object being attached:
          *
-         * - string => IDENTITY
-         * - byte array => BASE64
-         * - stream => BASE64
+         * - string: IDENTITY
+         * - byte array: BASE64
+         * - stream: BASE64
          */
         public readonly Attachment\ContentEncoding $contentEncoding = Attachment\ContentEncoding::IDENTITY,
 

--- a/php/src-generated/Exception.php
+++ b/php/src-generated/Exception.php
@@ -32,7 +32,7 @@ final class Exception implements JsonSerializable
         public readonly string $type = '',
 
         /**
-         * The message of exception that caused this result. E.g. expected: <"a"> but was: <"b">
+         * The message of exception that caused this result. E.g. expected: "a" but was: "b"
          */
         public readonly ?string $message = null,
     ) {

--- a/ruby/lib/cucumber/messages.dtos.rb
+++ b/ruby/lib/cucumber/messages.dtos.rb
@@ -41,9 +41,9 @@ module Cucumber
       #  Content encoding is *not* determined by the media type, but rather by the type
       #  of the object being attached:
       # 
-      #  - string => IDENTITY
-      #  - byte array => BASE64
-      #  - stream => BASE64
+      #  - string: IDENTITY
+      #  - byte array: BASE64
+      #  - stream: BASE64
 
       attr_reader :content_encoding
 
@@ -237,7 +237,7 @@ module Cucumber
       attr_reader :type
 
       ##
-      # The message of exception that caused this result. E.g. expected: <"a"> but was: <"b">
+      # The message of exception that caused this result. E.g. expected: "a" but was: "b"
 
       attr_reader :message
 


### PR DESCRIPTION
Fixes the broken release of https://github.com/cucumber/messages/actions/runs/3719910337/jobs/6309058882