### PR TITLE
Corrected Java and PHP code generation using Docker on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- Corrected Java and PHP generators to allow running using Docker on Windows ([#146](https://github.com/cucumber/messages/issues/146))
+
 ## [21.0.1] - 2022-12-17
 ### Fixed
 - [Java] Suppress warnings for missing javadoc ([#128](https://github.com/cucumber/messages/pull/128))

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,12 @@ This requires various tooling to be installed on your computer, including Ruby a
 docker run --volume $PWD:/app --user 1000 -it cucumber/cucumber-build:latest bash
 ```
 
+For Windows (Powershell):
+
+```shell
+docker run --volume  ${PWD}:/app --user 1000 -it cucumber/cucumber-build:latest bash
+```
+
 You can then run the same command as noted previously.
 
 ### New files
@@ -34,4 +40,4 @@ If you're adding a new file to the `jsonschema` directory, you'll need to add a 
 
 ## Tests
 
-Some of the language-specific diretories contain some smoke tests to ensure (de)serialization, validation etc are working right. If you happen to change one of the messages that's constructed by these tests, you may need to update them. If you're not sure, raise a draft PR and see what happens in CI.
+Some of the language-specific directories contain some smoke tests to ensure (de)serialization, validation etc are working right. If you happen to change one of the messages that's constructed by these tests, you may need to update them. If you're not sure, raise a draft PR and see what happens in CI.

--- a/java/Makefile
+++ b/java/Makefile
@@ -18,8 +18,8 @@ clean: ## Remove automatically generated files and related artifacts
 .generate-messages: $(schemas) ../jsonschema/scripts/codegen.rb ../jsonschema/scripts/templates/java.java.erb ../jsonschema/scripts/templates/java.enum.java.erb
 	ruby ../jsonschema/scripts/codegen.rb Java ../jsonschema java.java.erb > Generated.java.tmp
 	ruby ../jsonschema/scripts/codegen.rb Java ../jsonschema java.enum.java.erb >> Generated.java.tmp
-	csplit --quiet --prefix=Generated --suffix-format=%02d.java.tmp --elide-empty-files Generated.java.tmp /^.*[.]java$$/ {*}
+	csplit --quiet --prefix=Generated --suffix-format=%02d.java.tmp --elide-empty-files Generated.java.tmp /^[A-Za-z.]*[.]java/ {*}
 	rm Generated.java.tmp
 	rm -rf src/generated/java/io/cucumber/messages/types
 	mkdir --parents src/generated/java/io/cucumber/messages/types
-	for file in Generated**; do tail -n +2 $$file > src/generated/java/io/cucumber/messages/types/$$(head -n 1 $$file); rm $$file; done
+	for file in Generated**; do tail -n +2 $$file > src/generated/java/io/cucumber/messages/types/$$(head -n 1 $$file | tr -d '\r\n'); rm $$file; done

--- a/php/Makefile
+++ b/php/Makefile
@@ -14,13 +14,14 @@ require: ## Check requirements for the code generation (ruby, php, csplit, tail 
 
 clean: ## Remove automatically generated files and related artifacts
 	rm -rf build/messages.php
+	rm -rf build/Generated*.php.tmp
 	rm -rf src-generated/*
 
 build/messages.php: $(schemas) ../jsonschema/scripts/codegen.rb ../jsonschema/scripts/templates/php.php.erb ../jsonschema/scripts/templates/php.enum.php.erb
 	mkdir -p build
 	ruby ../jsonschema/scripts/codegen.rb Php ../jsonschema php.php.erb > build/messages.php
 	ruby ../jsonschema/scripts/codegen.rb Php ../jsonschema php.enum.php.erb >> build/messages.php
-	csplit --quiet --prefix=build/Generated --suffix-format=%02d.php.tmp --elide-empty-files build/messages.php /^.*[.]php$$/ {*}
+	csplit --quiet --prefix=build/Generated --suffix-format=%02d.php.tmp --elide-empty-files build/messages.php /^[A-Za-z/.]*[.]php/ {*}
 	rm -rf src-generated/*
-	for file in build/Generated**; do mkdir -p src-generated/$$(head -n 1 $$file | sed 's/[^/]*.php$$//'); done
-	for file in build/Generated**; do tail -n +2 $$file > src-generated/$$(head -n 1 $$file); rm $$file; done
+	for file in build/Generated**; do mkdir -p src-generated/$$(head -n 1 $$file | sed 's/[^/]*.php[\r]*$$//'); done
+	for file in build/Generated**; do tail -n +2 $$file > src-generated/$$(head -n 1 $$file | tr -d '\r\n'); rm $$file; done


### PR DESCRIPTION
### 🤔 What's changed?

I corrected the Java and PHP code generation when running using Docker on Windows.

### ⚡️ What's your motivation? 

Fixes #146

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?

It seems to be related to new lines differences between Unix and Windows.

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.
