### PR TITLE
Update cpan release action to v1.0.1

### DIFF
--- a/.github/workflows/release-cpan.yaml
+++ b/.github/workflows/release-cpan.yaml
@@ -13,7 +13,7 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v3
-      - uses: cucumber/action-publish-cpan@v1.0.0
+      - uses: cucumber/action-publish-cpan@v1.0.1
         with:
           cpan-user: ${{ secrets.CPAN_USER }}
           cpan-password: ${{ secrets.CPAN_PASSWORD }}


### PR DESCRIPTION
### 🤔 What's changed?

The version number of the CPAN release action is updated from 1.0.0 to 1.0.1.

### ⚡️ What's your motivation? 

The 1.0.1 version is updated for GitHub deprecation of `::set-output`.

### 🏷️ What kind of change is this?

:bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?



### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
