### PR TITLE
feat: add stackTrace prop to Exception message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Add `stackTrace` prop to `Exception` message ([#182](https://github.com/cucumber/messages/pull/182))
 
 ## [23.0.0] - 2023-11-01
 ### Added

--- a/cpp/include/cucumber/messages/exception.hpp
+++ b/cpp/include/cucumber/messages/exception.hpp
@@ -22,6 +22,7 @@ struct exception
 {
     std::string type;
     std::optional<std::string> message;
+    std::optional<std::string> stack_trace;
 
     std::string to_string() const;
 

--- a/cpp/src/lib/cucumber-messages/cucumber/messages/exception.cpp
+++ b/cpp/src/lib/cucumber-messages/cucumber/messages/exception.cpp
@@ -12,6 +12,7 @@ exception::to_string() const
 
     cucumber::messages::to_string(oss, "type=", type);
     cucumber::messages::to_string(oss, ", message=", message);
+    cucumber::messages::to_string(oss, ", stack_trace=", stack_trace);
 
     return oss.str();
 }
@@ -21,6 +22,7 @@ exception::to_json(json& j) const
 {
     cucumber::messages::to_json(j, camelize("type"), type);
     cucumber::messages::to_json(j, camelize("message"), message);
+    cucumber::messages::to_json(j, camelize("stack_trace"), stack_trace);
 }
 
 std::string

--- a/go/messages.go
+++ b/go/messages.go
@@ -37,8 +37,9 @@ type Envelope struct {
 }
 
 type Exception struct {
-	Type    string `json:"type"`
-	Message string `json:"message,omitempty"`
+	Type       string `json:"type"`
+	Message    string `json:"message,omitempty"`
+	StackTrace string `json:"stackTrace,omitempty"`
 }
 
 type GherkinDocument struct {

--- a/java/src/generated/java/io/cucumber/messages/types/Exception.java
+++ b/java/src/generated/java/io/cucumber/messages/types/Exception.java
@@ -18,13 +18,16 @@ import static java.util.Objects.requireNonNull;
 public final class Exception {
     private final String type;
     private final String message;
+    private final String stackTrace;
 
     public Exception(
         String type,
-        String message
+        String message,
+        String stackTrace
     ) {
         this.type = requireNonNull(type, "Exception.type cannot be null");
         this.message = message;
+        this.stackTrace = stackTrace;
     }
 
     /**
@@ -41,6 +44,13 @@ public final class Exception {
         return Optional.ofNullable(message);
     }
 
+    /**
+      * The stringified stack trace of the exception that caused this result
+     */
+    public Optional<String> getStackTrace() {
+        return Optional.ofNullable(stackTrace);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -48,14 +58,16 @@ public final class Exception {
         Exception that = (Exception) o;
         return 
             type.equals(that.type) &&         
-            Objects.equals(message, that.message);        
+            Objects.equals(message, that.message) &&         
+            Objects.equals(stackTrace, that.stackTrace);        
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(
             type,
-            message
+            message,
+            stackTrace
         );
     }
 
@@ -64,6 +76,7 @@ public final class Exception {
         return "Exception{" +
             "type=" + type +
             ", message=" + message +
+            ", stackTrace=" + stackTrace +
             '}';
     }
 }

--- a/java/src/main/java/io/cucumber/messages/Convertor.java
+++ b/java/src/main/java/io/cucumber/messages/Convertor.java
@@ -11,7 +11,7 @@ public final class Convertor {
     }
 
     public static Exception toMessage(Throwable t) {
-        return new Exception(t.getClass().getName(), t.getMessage());
+        return new Exception(t.getClass().getName(), t.getMessage(), null);
     }
 
     public static Timestamp toMessage(java.time.Instant instant) {

--- a/javascript/src/messages.ts
+++ b/javascript/src/messages.ts
@@ -87,6 +87,8 @@ export class Exception {
   type: string = ''
 
   message?: string
+
+  stackTrace?: string
 }
 
 export class GherkinDocument {

--- a/jsonschema/Exception.json
+++ b/jsonschema/Exception.json
@@ -14,6 +14,10 @@
     "message": {
       "type": "string",
       "description": "The message of exception that caused this result. E.g. expected: \"a\" but was: \"b\""
+    },
+    "stackTrace": {
+      "type": "string",
+      "description": "The stringified stack trace of the exception that caused this result"
     }
   },
   "type": "object"

--- a/messages.md
+++ b/messages.md
@@ -51,6 +51,7 @@ will only have one of its fields set, which indicates the payload of the message
 | ----- | ---- | ----------- | ----------- |
 | `type` | string | yes | |
 | `message` | string | no | |
+| `stackTrace` | string | no | |
 
 ## GherkinDocument
 

--- a/perl/lib/Cucumber/Messages.pm
+++ b/perl/lib/Cucumber/Messages.pm
@@ -546,6 +546,7 @@ use Scalar::Util qw( blessed );
 my %types = (
    type => 'string',
    message => 'string',
+   stack_trace => 'string',
 );
 
 # This is a work-around for the fact that Moo doesn't have introspection
@@ -576,6 +577,17 @@ The message of exception that caused this result. E.g. expected: "a" but was: "b
 =cut
 
 has message =>
+    (is => 'ro',
+    );
+
+
+=head4 stack_trace
+
+The stringified stack trace of the exception that caused this result
+
+=cut
+
+has stack_trace =>
     (is => 'ro',
     );
 

--- a/php/src-generated/Exception.php
+++ b/php/src-generated/Exception.php
@@ -35,6 +35,11 @@ final class Exception implements JsonSerializable
          * The message of exception that caused this result. E.g. expected: "a" but was: "b"
          */
         public readonly ?string $message = null,
+
+        /**
+         * The stringified stack trace of the exception that caused this result
+         */
+        public readonly ?string $stackTrace = null,
     ) {
     }
 
@@ -47,10 +52,12 @@ final class Exception implements JsonSerializable
     {
         self::ensureType($arr);
         self::ensureMessage($arr);
+        self::ensureStackTrace($arr);
 
         return new self(
             (string) $arr['type'],
             isset($arr['message']) ? (string) $arr['message'] : null,
+            isset($arr['stackTrace']) ? (string) $arr['stackTrace'] : null,
         );
     }
 
@@ -74,6 +81,16 @@ final class Exception implements JsonSerializable
     {
         if (array_key_exists('message', $arr) && is_array($arr['message'])) {
             throw new SchemaViolationException('Property \'message\' was array');
+        }
+    }
+
+    /**
+     * @psalm-assert array{stackTrace?: string|int|bool} $arr
+     */
+    private static function ensureStackTrace(array $arr): void
+    {
+        if (array_key_exists('stackTrace', $arr) && is_array($arr['stackTrace'])) {
+            throw new SchemaViolationException('Property \'stackTrace\' was array');
         }
     }
 }

--- a/ruby/lib/cucumber/messages.deserializers.rb
+++ b/ruby/lib/cucumber/messages.deserializers.rb
@@ -104,6 +104,7 @@ module Cucumber
         self.new(
           type: hash[:type],
           message: hash[:message],
+          stack_trace: hash[:stackTrace],
         )
       end
     end

--- a/ruby/lib/cucumber/messages.dtos.rb
+++ b/ruby/lib/cucumber/messages.dtos.rb
@@ -229,12 +229,19 @@ module Cucumber
       ##
       attr_reader :message
 
+      ##
+      # The stringified stack trace of the exception that caused this result
+      ##
+      attr_reader :stack_trace
+
       def initialize(
         type: '',
-        message: nil
+        message: nil,
+        stack_trace: nil
       )
         @type = type
         @message = message
+        @stack_trace = stack_trace
       end
     end
 


### PR DESCRIPTION
### 🤔 What's changed?

Adds an optional `stackTrace` prop to the `Exception` message schema, so implementations have the ability to include the message and stack trace separately.

### ⚡️ What's your motivation? 

See https://github.com/cucumber/cucumber-js/issues/2348#issuecomment-1804665880

Closes #70 (there is still a separate issue for adding “expected” and “actual” fields).

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :zap: New feature (non-breaking change which adds new behaviour)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
