### PR TITLE
Use variadic template args to support more kinds of containers

### DIFF
--- a/cpp/src/lib/cucumber-messages/cucumber/messages/utils.hpp
+++ b/cpp/src/lib/cucumber-messages/cucumber/messages/utils.hpp
@@ -15,15 +15,15 @@ using json = nlohmann::json;
 namespace detail {
 
 template <
-    template <typename> class Container,
-    template <typename> class Other,
+    template <typename ...> class Container,
+    template <typename ...> class Other,
     typename T
 >
 std::is_same<Container<T>, Other<T>>
 test_is_container(Other<T>*);
 
 template <
-    template <typename> class Container,
+    template <typename ...> class Container,
     typename T
 >
 std::false_type test_is_container(T*);
@@ -31,7 +31,7 @@ std::false_type test_is_container(T*);
 } // namespace detail
 
 template <
-    template <typename> class C,
+    template <typename ...> class C,
     typename T
 >
 using is_container = decltype(
@@ -39,7 +39,7 @@ using is_container = decltype(
 );
 
 template <
-    template <typename> class C,
+    template <typename ...> class C,
     typename T
 >
 inline


### PR DESCRIPTION
### 🤔 What's changed?
Updates templated `constexpr` used by C++ utility functions for compatibility with clang. 
The use of variadic template arguments for the container type allows containers with more than one type parameter to unify (to the best of my understanding)

### ⚡️ What's your motivation? 
Allows CPP messages to be built using clang, opening up development on Mac & any system using clang.

### 🏷️ What kind of change is this?
:bank: Improves build compatibility of cpp to work with clang.

### ♻️ Anything particular you want feedback on?
The solution itself & compatibility with compilers other than clang

### 📋 Checklist:
- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
