### PR TITLE
java: include stacktrace in Convertor.toMessage(Throwable)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added 
+-  java: include stacktrace in Convertor.toMessage(Throwable) ([#213](https://github.com/cucumber/messages/pull/213))
 
 ## [24.0.1] - 2023-12-21
 ### Fixed

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -88,6 +88,14 @@
         </resources>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <configuration>
+                    <propertiesEncoding>UTF-8</propertiesEncoding>
+                </configuration>
+            </plugin>
+
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
                 <executions>

--- a/java/src/main/java/io/cucumber/messages/Convertor.java
+++ b/java/src/main/java/io/cucumber/messages/Convertor.java
@@ -4,29 +4,47 @@ import io.cucumber.messages.types.Duration;
 import io.cucumber.messages.types.Exception;
 import io.cucumber.messages.types.Timestamp;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import static java.util.Objects.requireNonNull;
+
 public final class Convertor {
 
     private Convertor(){
 
     }
 
-    public static Exception toMessage(Throwable t) {
-        return new Exception(t.getClass().getName(), t.getMessage(), null);
+    public static Exception toMessage(Throwable throwable) {
+        requireNonNull(throwable, "throwable may not be null");
+        return new Exception(throwable.getClass().getName(), throwable.getMessage(), extractStackTrace(throwable));
+    }
+
+    private static String extractStackTrace(Throwable throwable) {
+        StringWriter stringWriter = new StringWriter();
+        try (PrintWriter printWriter = new PrintWriter(stringWriter)) {
+            throwable.printStackTrace(printWriter);
+        }
+        return stringWriter.toString();
     }
 
     public static Timestamp toMessage(java.time.Instant instant) {
+        requireNonNull(instant, "instant may not be null");
         return new Timestamp(instant.getEpochSecond(), (long) instant.getNano());
     }
 
     public static Duration toMessage(java.time.Duration duration) {
+        requireNonNull(duration, "duration may not be null");
         return new Duration(duration.getSeconds(), (long) duration.getNano());
     }
 
     public static java.time.Instant toInstant(Timestamp timestamp) {
+        requireNonNull(timestamp, "timestamp may not be null");
         return java.time.Instant.ofEpochSecond(timestamp.getSeconds(), timestamp.getNanos());
     }
 
     public static java.time.Duration toDuration(Duration duration) {
+        requireNonNull(duration, "duration may not be null");
         return java.time.Duration.ofSeconds(duration.getSeconds(), duration.getNanos());
     }
 

--- a/java/src/test/java/io/cucumber/messages/ConvertorTest.java
+++ b/java/src/test/java/io/cucumber/messages/ConvertorTest.java
@@ -9,18 +9,27 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ConvertorTest {
 
     @Test
     void convertsExceptionToMessage() {
+        Exception e = Convertor.toMessage(new RuntimeException());
+        assertAll(
+                () -> assertEquals(Optional.empty(), e.getMessage()),
+                () -> assertEquals("java.lang.RuntimeException", e.getType()),
+                () -> assertTrue(e.getStackTrace().isPresent())
+        );
+    }
+
+    @Test
+    void convertsExceptionWithMessageToMessage() {
         Exception e = Convertor.toMessage(new RuntimeException("Hello world!"));
-        Exception e2 = Convertor.toMessage(new RuntimeException());
         assertAll(
                 () -> assertEquals(Optional.of("Hello world!"), e.getMessage()),
-                () -> assertEquals(Optional.empty(), e2.getMessage()),
                 () -> assertEquals("java.lang.RuntimeException", e.getType()),
-                () -> assertEquals("java.lang.RuntimeException", e2.getType())
+                () -> assertTrue(e.getStackTrace().isPresent())
         );
     }
 


### PR DESCRIPTION
### 🤔 What's changed?

Includes the stack trace in exception messages when using the convertor.

### ⚡️ What's your motivation? 

Use it in the message based xml and html formatters (https://github.com/cucumber/cucumber-junit-xml-formatter/pull/30, https://github.com/cucumber/cucumber-jvm/pull/2862).

### 🏷️ What kind of change is this?

- :zap: New feature (non-breaking change which adds new behaviour)

### 📋 Checklist:


- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.
