### PR TITLE
Add slash at the end of COPY command to fix AVD-DS-0011

### DIFF
--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -12,7 +12,7 @@ FROM scratch AS schema-codegen
 
 FROM golang AS with-dependencies
 
-COPY --link go.mod go.sum .
+COPY --link go.mod go.sum ./
 RUN --mount=type=cache,target=/go/pkg/mod/cache \
     go mod download && go mod verify
 


### PR DESCRIPTION

### 🤔 What's changed?

Added slash at the end of COPY command to fix [AVD-DS-0011](https://avd.aquasec.com/misconfig/dockerfile/general/avd-ds-0011/)

### ⚡️ What's your motivation? 

Avoid error messages when scanning for security issues

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)

