### PR TITLE
Remove dependency on go fmt for code gen

### DIFF
--- a/codegen/templates/go.enum.go.erb
+++ b/codegen/templates/go.enum.go.erb
@@ -1,21 +1,26 @@
-<% @enums.each do |enum| -%>
+<% @enums.each_with_index do |enum, index| -%>
 type <%= enum[:name] %> string
 
-const(
+const (
+<%-
+  enum_constant_max_length = enum[:values].max_by { |value| enum_constant(value).length }.length
+-%>
 <% enum[:values].each do |value| -%>
-  <%= enum[:name] %>_<%= enum_constant(value) %> <%= enum[:name] %> = "<%= value %>"
+	<%=enum[:name] %>_<%= enum_constant(value).ljust(enum_constant_max_length) %> <%= enum[:name] %> = "<%= value %>"
 <% end -%>
 )
 
 func (e <%= enum[:name] %>) String() string {
 	switch e {
-  <%- enum[:values].each do |value| -%>
-  case <%= enum[:name] %>_<%= enum_constant(value) %>:
-    return "<%= value %>"
-  <%- end -%>
+	<%- enum[:values].each do |value| -%>
+	case <%= enum[:name] %>_<%= enum_constant(value) %>:
+		return "<%= value %>"
+	<%- end -%>
 	default:
 		panic("Bad enum value for <%= enum[:name] %>")
 	}
 }
+<%- if index != @enums.size - 1 -%>
 
-<% end -%>
+<%- end -%>
+<%- end -%>

--- a/codegen/templates/go.go.erb
+++ b/codegen/templates/go.go.erb
@@ -2,12 +2,16 @@ package messages
 
 <% @schemas.each do |key, schema| -%>
 type <%= class_name(key) %> struct {
-  <%- schema['properties'].each do |property_name, property| -%>
+  <%-
+  property_name_max_length = schema['properties'].max_by{ |property_name,_| property_name.length }[0].length
+  type_names = schema['properties'].map { |property_name, property| [property_name, type_for(class_name(key), property_name, property)] }
+  type_name_max_length = type_names.max_by{ |_,type_name| type_name.length }[1].length
+  -%>
+  <%- type_names.each do |property_name, type_name| -%>
     <%-
-      type_name = type_for(class_name(key), property_name, property)
       required = (schema['required'] || []).index(property_name)
     -%>
-    <%- %>  <%= capitalize(property_name) %> <%= type_name %> `json:"<%= property_name %><%= required ? '' : ',omitempty' %>"`
+    <%- %>	<%= capitalize(property_name).ljust(property_name_max_length) %> <%= type_name.ljust(type_name_max_length) %> `json:"<%= property_name %><%= required ? '' : ',omitempty' %>"`
   <%- end -%>
 }
 

--- a/go/Makefile
+++ b/go/Makefile
@@ -17,4 +17,3 @@ clean: ## Remove automatically generated files and related artifacts
 messages.go: $(schemas) ../codegen/codegen.rb ../codegen/templates/go.go.erb ../codegen/templates/go.enum.go.erb
 	ruby ../codegen/codegen.rb Generator::Go go.go.erb > $@
 	ruby ../codegen/codegen.rb Generator::Go go.enum.go.erb >> $@
-	go fmt messages.go


### PR DESCRIPTION
### 🤔 What's changed?

Removed dependency on go fmt when generating code by generating
properly formatted code.

### ⚡️ What's your motivation? 

Code generation should run with as few dependencies as possible to
make it easier for  all developers to use (i.e. without every one having to
install every dependency under the sun).


### 🏷️ What kind of change is this?
- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?

@luke-hill is this idiomatic enough?

### 📋 Checklist:


- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
