### PR TITLE
Schema: fix test case comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [Dotnet] Fixed code generation for types that accept List<T> as parameters. Constructors were not properly handling null input. ([#249](https://github.com/cucumber/messages/pull/249) [clrudolphi])
 ### Changed
 - [Go] Switch to Google's UUID module ([#251](https://github.com/cucumber/messages/pull/251))
+- Schema: moved contents of the description of the StepDefinitionIds field from the StepMatchArgumentsList`field where it had been mistakenly placed.[clrudolphi]`
 
 ## [26.0.0] - 2024-08-15
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Fixed
 - [Dotnet] Fixed code generation for types that accept List<T> as parameters. Constructors were not properly handling null input. ([#249](https://github.com/cucumber/messages/pull/249) [clrudolphi])
+- Moved contents of the description of the StepDefinitionIds field from the StepMatchArgumentsList field where it had been mistakenly placed. ([#252](https://github.com/cucumber/messages/pull/252) [clrudolphi])
+
 ### Changed
 - [Go] Switch to Google's UUID module ([#251](https://github.com/cucumber/messages/pull/251))
-- Schema: moved contents of the description of the StepDefinitionIds field from the StepMatchArgumentsList`field where it had been mistakenly placed.[clrudolphi]`
 
 ## [26.0.0] - 2024-08-15
 ### Added

--- a/dotnet/Cucumber.Messages/generated/TestStep.cs
+++ b/dotnet/Cucumber.Messages/generated/TestStep.cs
@@ -30,12 +30,12 @@ public sealed class TestStep
     public string PickleStepId { get; private set; }
     /**
      * Pointer to all the matching `StepDefinition`s (if derived from a `PickleStep`)
+     * Each element represents a matching step definition. A size of 0 means `UNDEFINED`,
+     * and a size of 2+ means `AMBIGUOUS`
      */
     public List<string> StepDefinitionIds { get; private set; }
     /**
      * A list of list of StepMatchArgument (if derived from a `PickleStep`).
-     * Each element represents a matching step definition. A size of 0 means `UNDEFINED`,
-     * and a size of 2+ means `AMBIGUOUS`
      */
     public List<StepMatchArgumentsList> StepMatchArgumentsLists { get; private set; }
 

--- a/java/src/generated/java/io/cucumber/messages/types/TestStep.java
+++ b/java/src/generated/java/io/cucumber/messages/types/TestStep.java
@@ -57,6 +57,8 @@ public final class TestStep {
 
     /**
       * Pointer to all the matching `StepDefinition`s (if derived from a `PickleStep`)
+     * Each element represents a matching step definition. A size of 0 means `UNDEFINED`,
+     * and a size of 2+ means `AMBIGUOUS`
      */
     public Optional<java.util.List<String>> getStepDefinitionIds() {
         return Optional.ofNullable(stepDefinitionIds);
@@ -64,8 +66,6 @@ public final class TestStep {
 
     /**
       * A list of list of StepMatchArgument (if derived from a `PickleStep`).
-     * Each element represents a matching step definition. A size of 0 means `UNDEFINED`,
-     * and a size of 2+ means `AMBIGUOUS`
      */
     public Optional<java.util.List<StepMatchArgumentsList>> getStepMatchArgumentsLists() {
         return Optional.ofNullable(stepMatchArgumentsLists);

--- a/jsonschema/TestCase.json
+++ b/jsonschema/TestCase.json
@@ -80,14 +80,14 @@
           "type": "string"
         },
         "stepDefinitionIds": {
-          "description": "Pointer to all the matching `StepDefinition`s (if derived from a `PickleStep`)",
+          "description": "Pointer to all the matching `StepDefinition`s (if derived from a `PickleStep`)\n Each element represents a matching step definition. A size of 0 means `UNDEFINED`,\n and a size of 2+ means `AMBIGUOUS`",
           "items": {
             "type": "string"
           },
           "type": "array"
         },
         "stepMatchArgumentsLists": {
-          "description": "A list of list of StepMatchArgument (if derived from a `PickleStep`).\n Each element represents a matching step definition. A size of 0 means `UNDEFINED`,\n and a size of 2+ means `AMBIGUOUS`",
+          "description": "A list of list of StepMatchArgument (if derived from a `PickleStep`).",
           "items": {
             "$ref": "#/definitions/StepMatchArgumentsList"
           },

--- a/perl/lib/Cucumber/Messages.pm
+++ b/perl/lib/Cucumber/Messages.pm
@@ -3968,6 +3968,8 @@ has pickle_step_id =>
 =head4 step_definition_ids
 
 Pointer to all the matching `StepDefinition`s (if derived from a `PickleStep`)
+ Each element represents a matching step definition. A size of 0 means `UNDEFINED`,
+ and a size of 2+ means `AMBIGUOUS`
 =cut
 
 has step_definition_ids =>
@@ -3978,8 +3980,6 @@ has step_definition_ids =>
 =head4 step_match_arguments_lists
 
 A list of list of StepMatchArgument (if derived from a `PickleStep`).
- Each element represents a matching step definition. A size of 0 means `UNDEFINED`,
- and a size of 2+ means `AMBIGUOUS`
 =cut
 
 has step_match_arguments_lists =>

--- a/php/src-generated/TestStep.php
+++ b/php/src-generated/TestStep.php
@@ -42,13 +42,13 @@ final class TestStep implements JsonSerializable
 
         /**
          * Pointer to all the matching `StepDefinition`s (if derived from a `PickleStep`)
+         * Each element represents a matching step definition. A size of 0 means `UNDEFINED`,
+         * and a size of 2+ means `AMBIGUOUS`
          */
         public readonly ?array $stepDefinitionIds = null,
 
         /**
          * A list of list of StepMatchArgument (if derived from a `PickleStep`).
-         * Each element represents a matching step definition. A size of 0 means `UNDEFINED`,
-         * and a size of 2+ means `AMBIGUOUS`
          */
         public readonly ?array $stepMatchArgumentsLists = null,
     ) {

--- a/ruby/lib/cucumber/messages/test_step.rb
+++ b/ruby/lib/cucumber/messages/test_step.rb
@@ -26,13 +26,13 @@ module Cucumber
 
       ##
       # Pointer to all the matching `StepDefinition`s (if derived from a `PickleStep`)
+      #  Each element represents a matching step definition. A size of 0 means `UNDEFINED`,
+      #  and a size of 2+ means `AMBIGUOUS`
       ##
       attr_reader :step_definition_ids
 
       ##
       # A list of list of StepMatchArgument (if derived from a `PickleStep`).
-      #  Each element represents a matching step definition. A size of 0 means `UNDEFINED`,
-      #  and a size of 2+ means `AMBIGUOUS`
       ##
       attr_reader :step_match_arguments_lists
 


### PR DESCRIPTION

### 🤔 What's changed?

The description comments in the schema for a TestStep's StepDefinitionIds was mistakenly placed on the neighboring StepMatchArgumentsList field. This PR moves that text to the description field of the StepDefinitionIds field.

### ⚡️ What's your motivation? 

Avoid confusion when reading the code.

### 🏷️ What kind of change is this?


- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?


### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [X ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
