### PR TITLE
Remove dependency on uuid package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
-
 ### Fixed
 - [python] Add a LICENSE file for Python ([#278](https://github.com/cucumber/messages/pull/278))
 - [.NET] Fix NuGet package generation
+
+### Removed
+- [JavaScript] Remove dependency on `uuid` package ([#284](https://github.com/cucumber/messages/pull/284)
 
 ## [27.2.0] - 2025-01-31
 ### Added

--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -9,10 +9,8 @@
       "version": "27.2.0",
       "license": "MIT",
       "dependencies": {
-        "@types/uuid": "10.0.0",
         "class-transformer": "0.5.1",
-        "reflect-metadata": "0.2.2",
-        "uuid": "11.0.5"
+        "reflect-metadata": "0.2.2"
       },
       "devDependencies": {
         "@types/mocha": "10.0.10",
@@ -205,11 +203,6 @@
       "dependencies": {
         "undici-types": "~6.20.0"
       }
-    },
-    "node_modules/@types/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ=="
     },
     "node_modules/acorn": {
       "version": "8.7.1",
@@ -1625,18 +1618,6 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
     },
-    "node_modules/uuid": {
-      "version": "11.0.5",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.5.tgz",
-      "integrity": "sha512-508e6IcKLrhxKdBbcA2b4KQZlLVp2+J5UwQ6F7Drckkc5N9ZJwFa4TgWtsww9UG8fGHbm6gbV19TdM5pQ4GaIA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
-    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -1929,11 +1910,6 @@
       "requires": {
         "undici-types": "~6.20.0"
       }
-    },
-    "@types/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ=="
     },
     "acorn": {
       "version": "8.7.1",
@@ -2970,11 +2946,6 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
-    },
-    "uuid": {
-      "version": "11.0.5",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.5.tgz",
-      "integrity": "sha512-508e6IcKLrhxKdBbcA2b4KQZlLVp2+J5UwQ6F7Drckkc5N9ZJwFa4TgWtsww9UG8fGHbm6gbV19TdM5pQ4GaIA=="
     },
     "v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -36,10 +36,8 @@
     "prepublishOnly": "npm run build && npm run copy-schemas"
   },
   "dependencies": {
-    "@types/uuid": "10.0.0",
     "class-transformer": "0.5.1",
-    "reflect-metadata": "0.2.2",
-    "uuid": "11.0.5"
+    "reflect-metadata": "0.2.2"
   },
   "devDependencies": {
     "@types/mocha": "10.0.10",

--- a/javascript/src/IdGenerator.ts
+++ b/javascript/src/IdGenerator.ts
@@ -1,9 +1,7 @@
-import { v4 as uuidv4 } from 'uuid'
-
 export type NewId = () => string
 
 export function uuid(): NewId {
-  return () => uuidv4()
+  return () => crypto.randomUUID()
 }
 
 export function incrementing(): NewId {


### PR DESCRIPTION
### 🤔 What's changed?

Use the [JavaScript standard](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID) `crypto.randomUUID()` for the UUID generator, rather than the `uuid` module.

### ⚡️ What's your motivation? 

Reduce dependencies.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
