### PR TITLE
Fix the code snippet in the PHP readme

### DIFF
--- a/php/README.md
+++ b/php/README.md
@@ -118,8 +118,8 @@ $writer = new NdJsonStreamWriter($fh)
 
 // write a fixed array of envelopes
 $envArray = [
-    new Envelope('gherkinDocument': new GherkinDocument()),
-    new Envelope('gherkinDocument': new GherkinDocument()),
+    new Envelope(gherkinDocument: new GherkinDocument()),
+    new Envelope(gherkinDocument: new GherkinDocument()),
 ];
 $writer->write($envArray);
 


### PR DESCRIPTION
### 🤔 What's changed?

Fixing the code snippet in the PHP readme.

### ⚡️ What's your motivation? 

When using named parameters in PHP, the argument name is not quoted.
The current code snippet would have triggered a syntax error when running it.

### 🏷️ What kind of change is this?

- :book: Documentation (improvements without changing code)

### ♻️ Anything particular you want feedback on?



### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
