### PR TITLE
Clean up json schema descriptions and generated documentation

### DIFF
--- a/codegen/generators/java.rb
+++ b/codegen/generators/java.rb
@@ -15,7 +15,9 @@ module Generator
         .split("\n")
         .map(&:strip)
         .reject { |line| line == '*' }
-        .map { |line| " * #{line}".rstrip }
+        .map { |line| line.rstrip }
+        .map { |line| line.empty? ? "<p>" : line }
+        .map { |line| " * #{line}"}
         .join("\n#{indent_string}")
     end
 

--- a/codegen/templates/java.java.erb
+++ b/codegen/templates/java.java.erb
@@ -10,10 +10,9 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Represents the <%= class_name(key) %> message in Cucumber's message protocol
- * @see <a href=https://github.com/cucumber/messages>Github - Cucumber - Messages</a>
+ * Represents the <%= class_name(key) %> message in <a href=https://github.com/cucumber/messages>Cucumber's message protocol</a>
  <%- unless (schema['description'] || []).empty? -%>
- *
+ * <p>
 <%= format_description(schema['description'], indent_string: '') %>
 <%- end -%>
  */

--- a/cpp/include/messages/cucumber/messages/attachment.hpp
+++ b/cpp/include/messages/cucumber/messages/attachment.hpp
@@ -18,7 +18,7 @@ using json = nlohmann::json;
 // Represents the Attachment message in Cucumber's message protocol
 // @see <a href=https://github.com/cucumber/messages>Github - Cucumber - Messages</a>
 //
-// //// Attachments (parse errors, execution errors, screenshots, links...)
+// Attachments (parse errors, execution errors, screenshots, links...)
 //
 // An attachment represents any kind of data associated with a line in a
 // [Source](#io.cucumber.messages.Source) file. It can be used for:

--- a/cpp/include/messages/cucumber/messages/envelope.hpp
+++ b/cpp/include/messages/cucumber/messages/envelope.hpp
@@ -34,13 +34,6 @@ using json = nlohmann::json;
 // Represents the Envelope message in Cucumber's message protocol
 // @see <a href=https://github.com/cucumber/messages>Github - Cucumber - Messages</a>
 //
-// When removing a field, replace it with reserved, rather than deleting the line.
-// When adding a field, add it to the end and increment the number by one.
-// See https://developers.google.com/protocol-buffers/docs/proto#updating for details
-//
-// All the messages that are passed between different components/processes are Envelope
-// messages.
-//
 // Generated code
 
 struct envelope

--- a/cpp/include/messages/cucumber/messages/pickle.hpp
+++ b/cpp/include/messages/cucumber/messages/pickle.hpp
@@ -17,8 +17,6 @@ using json = nlohmann::json;
 // Represents the Pickle message in Cucumber's message protocol
 // @see <a href=https://github.com/cucumber/messages>Github - Cucumber - Messages</a>
 //
-// //// Pickles
-//
 // A `Pickle` represents a template for a `TestCase`. It is typically derived
 // from another format, such as [GherkinDocument](#io.cucumber.messages.GherkinDocument).
 // In the future a `Pickle` may be derived from other formats such as Markdown or

--- a/cpp/include/messages/cucumber/messages/source.hpp
+++ b/cpp/include/messages/cucumber/messages/source.hpp
@@ -16,8 +16,6 @@ using json = nlohmann::json;
 // Represents the Source message in Cucumber's message protocol
 // @see <a href=https://github.com/cucumber/messages>Github - Cucumber - Messages</a>
 //
-// //// Source
-//
 // A source file, typically a Gherkin document or Java/Ruby/JavaScript source code
 //
 // Generated code

--- a/cpp/include/messages/cucumber/messages/test_case.hpp
+++ b/cpp/include/messages/cucumber/messages/test_case.hpp
@@ -16,8 +16,6 @@ using json = nlohmann::json;
 // Represents the TestCase message in Cucumber's message protocol
 // @see <a href=https://github.com/cucumber/messages>Github - Cucumber - Messages</a>
 //
-// //// TestCases
-//
 // A `TestCase` contains a sequence of `TestStep`s.
 //
 // Generated code

--- a/dotnet/Cucumber.Messages/generated/Attachment.cs
+++ b/dotnet/Cucumber.Messages/generated/Attachment.cs
@@ -13,7 +13,7 @@ namespace Io.Cucumber.Messages.Types;
  * Represents the Attachment message in Cucumber's message protocol
  * @see <a href="https://github.com/cucumber/messages" >Github - Cucumber - Messages</a>
  *
- * //// Attachments (parse errors, execution errors, screenshots, links...)
+ * Attachments (parse errors, execution errors, screenshots, links...)
  *
  * An attachment represents any kind of data associated with a line in a
  * [Source](#io.cucumber.messages.Source) file. It can be used for:

--- a/dotnet/Cucumber.Messages/generated/Envelope.cs
+++ b/dotnet/Cucumber.Messages/generated/Envelope.cs
@@ -12,13 +12,6 @@ namespace Io.Cucumber.Messages.Types;
 /**
  * Represents the Envelope message in Cucumber's message protocol
  * @see <a href="https://github.com/cucumber/messages" >Github - Cucumber - Messages</a>
- *
- * When removing a field, replace it with reserved, rather than deleting the line.
- * When adding a field, add it to the end and increment the number by one.
- * See https://developers.google.com/protocol-buffers/docs/proto#updating for details
- *
- * All the messages that are passed between different components/processes are Envelope
- * messages.
  */
 
 public sealed class Envelope 

--- a/dotnet/Cucumber.Messages/generated/Pickle.cs
+++ b/dotnet/Cucumber.Messages/generated/Pickle.cs
@@ -13,8 +13,6 @@ namespace Io.Cucumber.Messages.Types;
  * Represents the Pickle message in Cucumber's message protocol
  * @see <a href="https://github.com/cucumber/messages" >Github - Cucumber - Messages</a>
  *
- * //// Pickles
- *
  * A `Pickle` represents a template for a `TestCase`. It is typically derived
  * from another format, such as [GherkinDocument](#io.cucumber.messages.GherkinDocument).
  * In the future a `Pickle` may be derived from other formats such as Markdown or

--- a/dotnet/Cucumber.Messages/generated/Source.cs
+++ b/dotnet/Cucumber.Messages/generated/Source.cs
@@ -13,8 +13,6 @@ namespace Io.Cucumber.Messages.Types;
  * Represents the Source message in Cucumber's message protocol
  * @see <a href="https://github.com/cucumber/messages" >Github - Cucumber - Messages</a>
  *
- * //// Source
- *
  * A source file, typically a Gherkin document or Java/Ruby/JavaScript source code
  */
 

--- a/dotnet/Cucumber.Messages/generated/TestCase.cs
+++ b/dotnet/Cucumber.Messages/generated/TestCase.cs
@@ -13,8 +13,6 @@ namespace Io.Cucumber.Messages.Types;
  * Represents the TestCase message in Cucumber's message protocol
  * @see <a href="https://github.com/cucumber/messages" >Github - Cucumber - Messages</a>
  *
- * //// TestCases
- *
  * A `TestCase` contains a sequence of `TestStep`s.
  */
 

--- a/java/src/generated/java/io/cucumber/messages/types/Attachment.java
+++ b/java/src/generated/java/io/cucumber/messages/types/Attachment.java
@@ -8,18 +8,17 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Represents the Attachment message in Cucumber's message protocol
- * @see <a href=https://github.com/cucumber/messages>Github - Cucumber - Messages</a>
- *
- * //// Attachments (parse errors, execution errors, screenshots, links...)
- *
+ * Represents the Attachment message in <a href=https://github.com/cucumber/messages>Cucumber's message protocol</a>
+ * <p>
+ * Attachments (parse errors, execution errors, screenshots, links...)
+ * <p>
  * An attachment represents any kind of data associated with a line in a
  * [Source](#io.cucumber.messages.Source) file. It can be used for:
- *
+ * <p>
  * * Syntax errors during parse time
  * * Screenshots captured and attached during execution
  * * Logs captured and attached during execution
- *
+ * <p>
  * It is not to be used for runtime errors raised/thrown during execution. This
  * is captured in `TestResult`.
  */
@@ -75,10 +74,10 @@ public final class Attachment {
 
     /**
      * Whether to interpret `body` "as-is" (IDENTITY) or if it needs to be Base64-decoded (BASE64).
-     *
+     * <p>
      * Content encoding is *not* determined by the media type, but rather by the type
      * of the object being attached:
-     *
+     * <p>
      * - string: IDENTITY
      * - byte array: BASE64
      * - stream: BASE64
@@ -126,11 +125,11 @@ public final class Attachment {
       * A URL where the attachment can be retrieved. This field should not be set by Cucumber.
      * It should be set by a program that reads a message stream and does the following for
      * each Attachment message:
-     *
+     * <p>
      * - Writes the body (after base64 decoding if necessary) to a new file.
      * - Sets `body` and `contentEncoding` to `null`
      * - Writes out the new attachment message
-     *
+     * <p>
      * This will result in a smaller message stream, which can improve performance and
      * reduce bandwidth of message consumers. It also makes it easier to process and download attachments
      * separately from reports.

--- a/java/src/generated/java/io/cucumber/messages/types/Background.java
+++ b/java/src/generated/java/io/cucumber/messages/types/Background.java
@@ -8,8 +8,7 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Represents the Background message in Cucumber's message protocol
- * @see <a href=https://github.com/cucumber/messages>Github - Cucumber - Messages</a>
+ * Represents the Background message in <a href=https://github.com/cucumber/messages>Cucumber's message protocol</a>
  */
 // Generated code
 @SuppressWarnings("unused")

--- a/java/src/generated/java/io/cucumber/messages/types/Ci.java
+++ b/java/src/generated/java/io/cucumber/messages/types/Ci.java
@@ -8,9 +8,8 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Represents the Ci message in Cucumber's message protocol
- * @see <a href=https://github.com/cucumber/messages>Github - Cucumber - Messages</a>
- *
+ * Represents the Ci message in <a href=https://github.com/cucumber/messages>Cucumber's message protocol</a>
+ * <p>
  * CI environment
  */
 // Generated code

--- a/java/src/generated/java/io/cucumber/messages/types/Comment.java
+++ b/java/src/generated/java/io/cucumber/messages/types/Comment.java
@@ -8,9 +8,8 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Represents the Comment message in Cucumber's message protocol
- * @see <a href=https://github.com/cucumber/messages>Github - Cucumber - Messages</a>
- *
+ * Represents the Comment message in <a href=https://github.com/cucumber/messages>Cucumber's message protocol</a>
+ * <p>
  * A comment in a Gherkin document
  */
 // Generated code

--- a/java/src/generated/java/io/cucumber/messages/types/DataTable.java
+++ b/java/src/generated/java/io/cucumber/messages/types/DataTable.java
@@ -8,8 +8,7 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Represents the DataTable message in Cucumber's message protocol
- * @see <a href=https://github.com/cucumber/messages>Github - Cucumber - Messages</a>
+ * Represents the DataTable message in <a href=https://github.com/cucumber/messages>Cucumber's message protocol</a>
  */
 // Generated code
 @SuppressWarnings("unused")

--- a/java/src/generated/java/io/cucumber/messages/types/DocString.java
+++ b/java/src/generated/java/io/cucumber/messages/types/DocString.java
@@ -8,8 +8,7 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Represents the DocString message in Cucumber's message protocol
- * @see <a href=https://github.com/cucumber/messages>Github - Cucumber - Messages</a>
+ * Represents the DocString message in <a href=https://github.com/cucumber/messages>Cucumber's message protocol</a>
  */
 // Generated code
 @SuppressWarnings("unused")

--- a/java/src/generated/java/io/cucumber/messages/types/Duration.java
+++ b/java/src/generated/java/io/cucumber/messages/types/Duration.java
@@ -8,9 +8,8 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Represents the Duration message in Cucumber's message protocol
- * @see <a href=https://github.com/cucumber/messages>Github - Cucumber - Messages</a>
- *
+ * Represents the Duration message in <a href=https://github.com/cucumber/messages>Cucumber's message protocol</a>
+ * <p>
  * The structure is pretty close of the Timestamp one. For clarity, a second type
  * of message is used.
  */

--- a/java/src/generated/java/io/cucumber/messages/types/Envelope.java
+++ b/java/src/generated/java/io/cucumber/messages/types/Envelope.java
@@ -8,15 +8,7 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Represents the Envelope message in Cucumber's message protocol
- * @see <a href=https://github.com/cucumber/messages>Github - Cucumber - Messages</a>
- *
- * When removing a field, replace it with reserved, rather than deleting the line.
- * When adding a field, add it to the end and increment the number by one.
- * See https://developers.google.com/protocol-buffers/docs/proto#updating for details
- *
- * All the messages that are passed between different components/processes are Envelope
- * messages.
+ * Represents the Envelope message in <a href=https://github.com/cucumber/messages>Cucumber's message protocol</a>
  */
 // Generated code
 @SuppressWarnings("unused")

--- a/java/src/generated/java/io/cucumber/messages/types/Examples.java
+++ b/java/src/generated/java/io/cucumber/messages/types/Examples.java
@@ -8,8 +8,7 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Represents the Examples message in Cucumber's message protocol
- * @see <a href=https://github.com/cucumber/messages>Github - Cucumber - Messages</a>
+ * Represents the Examples message in <a href=https://github.com/cucumber/messages>Cucumber's message protocol</a>
  */
 // Generated code
 @SuppressWarnings("unused")

--- a/java/src/generated/java/io/cucumber/messages/types/Exception.java
+++ b/java/src/generated/java/io/cucumber/messages/types/Exception.java
@@ -8,9 +8,8 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Represents the Exception message in Cucumber's message protocol
- * @see <a href=https://github.com/cucumber/messages>Github - Cucumber - Messages</a>
- *
+ * Represents the Exception message in <a href=https://github.com/cucumber/messages>Cucumber's message protocol</a>
+ * <p>
  * A simplified representation of an exception
  */
 // Generated code

--- a/java/src/generated/java/io/cucumber/messages/types/Feature.java
+++ b/java/src/generated/java/io/cucumber/messages/types/Feature.java
@@ -8,8 +8,7 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Represents the Feature message in Cucumber's message protocol
- * @see <a href=https://github.com/cucumber/messages>Github - Cucumber - Messages</a>
+ * Represents the Feature message in <a href=https://github.com/cucumber/messages>Cucumber's message protocol</a>
  */
 // Generated code
 @SuppressWarnings("unused")

--- a/java/src/generated/java/io/cucumber/messages/types/FeatureChild.java
+++ b/java/src/generated/java/io/cucumber/messages/types/FeatureChild.java
@@ -8,9 +8,8 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Represents the FeatureChild message in Cucumber's message protocol
- * @see <a href=https://github.com/cucumber/messages>Github - Cucumber - Messages</a>
- *
+ * Represents the FeatureChild message in <a href=https://github.com/cucumber/messages>Cucumber's message protocol</a>
+ * <p>
  * A child node of a `Feature` node
  */
 // Generated code

--- a/java/src/generated/java/io/cucumber/messages/types/GherkinDocument.java
+++ b/java/src/generated/java/io/cucumber/messages/types/GherkinDocument.java
@@ -8,13 +8,12 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Represents the GherkinDocument message in Cucumber's message protocol
- * @see <a href=https://github.com/cucumber/messages>Github - Cucumber - Messages</a>
- *
+ * Represents the GherkinDocument message in <a href=https://github.com/cucumber/messages>Cucumber's message protocol</a>
+ * <p>
  * The [AST](https://en.wikipedia.org/wiki/Abstract_syntax_tree) of a Gherkin document.
  * Cucumber implementations should *not* depend on `GherkinDocument` or any of its
  * children for execution - use [Pickle](#io.cucumber.messages.Pickle) instead.
- *
+ * <p>
  * The only consumers of `GherkinDocument` should only be formatters that produce
  * "rich" output, resembling the original Gherkin document.
  */

--- a/java/src/generated/java/io/cucumber/messages/types/Git.java
+++ b/java/src/generated/java/io/cucumber/messages/types/Git.java
@@ -8,9 +8,8 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Represents the Git message in Cucumber's message protocol
- * @see <a href=https://github.com/cucumber/messages>Github - Cucumber - Messages</a>
- *
+ * Represents the Git message in <a href=https://github.com/cucumber/messages>Cucumber's message protocol</a>
+ * <p>
  * Information about Git, provided by the Build/CI server as environment
  * variables.
  */

--- a/java/src/generated/java/io/cucumber/messages/types/Group.java
+++ b/java/src/generated/java/io/cucumber/messages/types/Group.java
@@ -8,8 +8,7 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Represents the Group message in Cucumber's message protocol
- * @see <a href=https://github.com/cucumber/messages>Github - Cucumber - Messages</a>
+ * Represents the Group message in <a href=https://github.com/cucumber/messages>Cucumber's message protocol</a>
  */
 // Generated code
 @SuppressWarnings("unused")

--- a/java/src/generated/java/io/cucumber/messages/types/Hook.java
+++ b/java/src/generated/java/io/cucumber/messages/types/Hook.java
@@ -8,8 +8,7 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Represents the Hook message in Cucumber's message protocol
- * @see <a href=https://github.com/cucumber/messages>Github - Cucumber - Messages</a>
+ * Represents the Hook message in <a href=https://github.com/cucumber/messages>Cucumber's message protocol</a>
  */
 // Generated code
 @SuppressWarnings("unused")

--- a/java/src/generated/java/io/cucumber/messages/types/JavaMethod.java
+++ b/java/src/generated/java/io/cucumber/messages/types/JavaMethod.java
@@ -8,8 +8,7 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Represents the JavaMethod message in Cucumber's message protocol
- * @see <a href=https://github.com/cucumber/messages>Github - Cucumber - Messages</a>
+ * Represents the JavaMethod message in <a href=https://github.com/cucumber/messages>Cucumber's message protocol</a>
  */
 // Generated code
 @SuppressWarnings("unused")

--- a/java/src/generated/java/io/cucumber/messages/types/JavaStackTraceElement.java
+++ b/java/src/generated/java/io/cucumber/messages/types/JavaStackTraceElement.java
@@ -8,8 +8,7 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Represents the JavaStackTraceElement message in Cucumber's message protocol
- * @see <a href=https://github.com/cucumber/messages>Github - Cucumber - Messages</a>
+ * Represents the JavaStackTraceElement message in <a href=https://github.com/cucumber/messages>Cucumber's message protocol</a>
  */
 // Generated code
 @SuppressWarnings("unused")

--- a/java/src/generated/java/io/cucumber/messages/types/Location.java
+++ b/java/src/generated/java/io/cucumber/messages/types/Location.java
@@ -8,9 +8,8 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Represents the Location message in Cucumber's message protocol
- * @see <a href=https://github.com/cucumber/messages>Github - Cucumber - Messages</a>
- *
+ * Represents the Location message in <a href=https://github.com/cucumber/messages>Cucumber's message protocol</a>
+ * <p>
  * Points to a line and a column in a text file
  */
 // Generated code

--- a/java/src/generated/java/io/cucumber/messages/types/Meta.java
+++ b/java/src/generated/java/io/cucumber/messages/types/Meta.java
@@ -8,9 +8,8 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Represents the Meta message in Cucumber's message protocol
- * @see <a href=https://github.com/cucumber/messages>Github - Cucumber - Messages</a>
- *
+ * Represents the Meta message in <a href=https://github.com/cucumber/messages>Cucumber's message protocol</a>
+ * <p>
  * This message contains meta information about the environment. Consumers can use
  * this for various purposes.
  */

--- a/java/src/generated/java/io/cucumber/messages/types/ParameterType.java
+++ b/java/src/generated/java/io/cucumber/messages/types/ParameterType.java
@@ -8,8 +8,7 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Represents the ParameterType message in Cucumber's message protocol
- * @see <a href=https://github.com/cucumber/messages>Github - Cucumber - Messages</a>
+ * Represents the ParameterType message in <a href=https://github.com/cucumber/messages>Cucumber's message protocol</a>
  */
 // Generated code
 @SuppressWarnings("unused")

--- a/java/src/generated/java/io/cucumber/messages/types/ParseError.java
+++ b/java/src/generated/java/io/cucumber/messages/types/ParseError.java
@@ -8,8 +8,7 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Represents the ParseError message in Cucumber's message protocol
- * @see <a href=https://github.com/cucumber/messages>Github - Cucumber - Messages</a>
+ * Represents the ParseError message in <a href=https://github.com/cucumber/messages>Cucumber's message protocol</a>
  */
 // Generated code
 @SuppressWarnings("unused")

--- a/java/src/generated/java/io/cucumber/messages/types/Pickle.java
+++ b/java/src/generated/java/io/cucumber/messages/types/Pickle.java
@@ -8,20 +8,17 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Represents the Pickle message in Cucumber's message protocol
- * @see <a href=https://github.com/cucumber/messages>Github - Cucumber - Messages</a>
- *
- * //// Pickles
- *
+ * Represents the Pickle message in <a href=https://github.com/cucumber/messages>Cucumber's message protocol</a>
+ * <p>
  * A `Pickle` represents a template for a `TestCase`. It is typically derived
  * from another format, such as [GherkinDocument](#io.cucumber.messages.GherkinDocument).
  * In the future a `Pickle` may be derived from other formats such as Markdown or
  * Excel files.
- *
+ * <p>
  * By making `Pickle` the main data structure Cucumber uses for execution, the
  * implementation of Cucumber itself becomes simpler, as it doesn't have to deal
  * with the complex structure of a [GherkinDocument](#io.cucumber.messages.GherkinDocument).
- *
+ * <p>
  * Each `PickleStep` of a `Pickle` is matched with a `StepDefinition` to create a `TestCase`
  */
 // Generated code

--- a/java/src/generated/java/io/cucumber/messages/types/PickleDocString.java
+++ b/java/src/generated/java/io/cucumber/messages/types/PickleDocString.java
@@ -8,8 +8,7 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Represents the PickleDocString message in Cucumber's message protocol
- * @see <a href=https://github.com/cucumber/messages>Github - Cucumber - Messages</a>
+ * Represents the PickleDocString message in <a href=https://github.com/cucumber/messages>Cucumber's message protocol</a>
  */
 // Generated code
 @SuppressWarnings("unused")

--- a/java/src/generated/java/io/cucumber/messages/types/PickleStep.java
+++ b/java/src/generated/java/io/cucumber/messages/types/PickleStep.java
@@ -8,9 +8,8 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Represents the PickleStep message in Cucumber's message protocol
- * @see <a href=https://github.com/cucumber/messages>Github - Cucumber - Messages</a>
- *
+ * Represents the PickleStep message in <a href=https://github.com/cucumber/messages>Cucumber's message protocol</a>
+ * <p>
  * An executable step
  */
 // Generated code
@@ -57,7 +56,7 @@ public final class PickleStep {
 
     /**
       * The context in which the step was specified: context (Given), action (When) or outcome (Then).
-     *
+     * <p>
      * Note that the keywords `But` and `And` inherit their meaning from prior steps and the `*` 'keyword' doesn't have specific meaning (hence Unknown)
      */
     public Optional<PickleStepType> getType() {

--- a/java/src/generated/java/io/cucumber/messages/types/PickleStepArgument.java
+++ b/java/src/generated/java/io/cucumber/messages/types/PickleStepArgument.java
@@ -8,9 +8,8 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Represents the PickleStepArgument message in Cucumber's message protocol
- * @see <a href=https://github.com/cucumber/messages>Github - Cucumber - Messages</a>
- *
+ * Represents the PickleStepArgument message in <a href=https://github.com/cucumber/messages>Cucumber's message protocol</a>
+ * <p>
  * An optional argument
  */
 // Generated code

--- a/java/src/generated/java/io/cucumber/messages/types/PickleTable.java
+++ b/java/src/generated/java/io/cucumber/messages/types/PickleTable.java
@@ -8,8 +8,7 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Represents the PickleTable message in Cucumber's message protocol
- * @see <a href=https://github.com/cucumber/messages>Github - Cucumber - Messages</a>
+ * Represents the PickleTable message in <a href=https://github.com/cucumber/messages>Cucumber's message protocol</a>
  */
 // Generated code
 @SuppressWarnings("unused")

--- a/java/src/generated/java/io/cucumber/messages/types/PickleTableCell.java
+++ b/java/src/generated/java/io/cucumber/messages/types/PickleTableCell.java
@@ -8,8 +8,7 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Represents the PickleTableCell message in Cucumber's message protocol
- * @see <a href=https://github.com/cucumber/messages>Github - Cucumber - Messages</a>
+ * Represents the PickleTableCell message in <a href=https://github.com/cucumber/messages>Cucumber's message protocol</a>
  */
 // Generated code
 @SuppressWarnings("unused")

--- a/java/src/generated/java/io/cucumber/messages/types/PickleTableRow.java
+++ b/java/src/generated/java/io/cucumber/messages/types/PickleTableRow.java
@@ -8,8 +8,7 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Represents the PickleTableRow message in Cucumber's message protocol
- * @see <a href=https://github.com/cucumber/messages>Github - Cucumber - Messages</a>
+ * Represents the PickleTableRow message in <a href=https://github.com/cucumber/messages>Cucumber's message protocol</a>
  */
 // Generated code
 @SuppressWarnings("unused")

--- a/java/src/generated/java/io/cucumber/messages/types/PickleTag.java
+++ b/java/src/generated/java/io/cucumber/messages/types/PickleTag.java
@@ -8,9 +8,8 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Represents the PickleTag message in Cucumber's message protocol
- * @see <a href=https://github.com/cucumber/messages>Github - Cucumber - Messages</a>
- *
+ * Represents the PickleTag message in <a href=https://github.com/cucumber/messages>Cucumber's message protocol</a>
+ * <p>
  * A tag
  */
 // Generated code

--- a/java/src/generated/java/io/cucumber/messages/types/Product.java
+++ b/java/src/generated/java/io/cucumber/messages/types/Product.java
@@ -8,9 +8,8 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Represents the Product message in Cucumber's message protocol
- * @see <a href=https://github.com/cucumber/messages>Github - Cucumber - Messages</a>
- *
+ * Represents the Product message in <a href=https://github.com/cucumber/messages>Cucumber's message protocol</a>
+ * <p>
  * Used to describe various properties of Meta
  */
 // Generated code

--- a/java/src/generated/java/io/cucumber/messages/types/Rule.java
+++ b/java/src/generated/java/io/cucumber/messages/types/Rule.java
@@ -8,8 +8,7 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Represents the Rule message in Cucumber's message protocol
- * @see <a href=https://github.com/cucumber/messages>Github - Cucumber - Messages</a>
+ * Represents the Rule message in <a href=https://github.com/cucumber/messages>Cucumber's message protocol</a>
  */
 // Generated code
 @SuppressWarnings("unused")

--- a/java/src/generated/java/io/cucumber/messages/types/RuleChild.java
+++ b/java/src/generated/java/io/cucumber/messages/types/RuleChild.java
@@ -8,9 +8,8 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Represents the RuleChild message in Cucumber's message protocol
- * @see <a href=https://github.com/cucumber/messages>Github - Cucumber - Messages</a>
- *
+ * Represents the RuleChild message in <a href=https://github.com/cucumber/messages>Cucumber's message protocol</a>
+ * <p>
  * A child node of a `Rule` node
  */
 // Generated code

--- a/java/src/generated/java/io/cucumber/messages/types/Scenario.java
+++ b/java/src/generated/java/io/cucumber/messages/types/Scenario.java
@@ -8,8 +8,7 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Represents the Scenario message in Cucumber's message protocol
- * @see <a href=https://github.com/cucumber/messages>Github - Cucumber - Messages</a>
+ * Represents the Scenario message in <a href=https://github.com/cucumber/messages>Cucumber's message protocol</a>
  */
 // Generated code
 @SuppressWarnings("unused")

--- a/java/src/generated/java/io/cucumber/messages/types/Source.java
+++ b/java/src/generated/java/io/cucumber/messages/types/Source.java
@@ -8,11 +8,8 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Represents the Source message in Cucumber's message protocol
- * @see <a href=https://github.com/cucumber/messages>Github - Cucumber - Messages</a>
- *
- * //// Source
- *
+ * Represents the Source message in <a href=https://github.com/cucumber/messages>Cucumber's message protocol</a>
+ * <p>
  * A source file, typically a Gherkin document or Java/Ruby/JavaScript source code
  */
 // Generated code

--- a/java/src/generated/java/io/cucumber/messages/types/SourceReference.java
+++ b/java/src/generated/java/io/cucumber/messages/types/SourceReference.java
@@ -8,9 +8,8 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Represents the SourceReference message in Cucumber's message protocol
- * @see <a href=https://github.com/cucumber/messages>Github - Cucumber - Messages</a>
- *
+ * Represents the SourceReference message in <a href=https://github.com/cucumber/messages>Cucumber's message protocol</a>
+ * <p>
  * Points to a [Source](#io.cucumber.messages.Source) identified by `uri` and a
  * [Location](#io.cucumber.messages.Location) within that file.
  */

--- a/java/src/generated/java/io/cucumber/messages/types/Step.java
+++ b/java/src/generated/java/io/cucumber/messages/types/Step.java
@@ -8,9 +8,8 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Represents the Step message in Cucumber's message protocol
- * @see <a href=https://github.com/cucumber/messages>Github - Cucumber - Messages</a>
- *
+ * Represents the Step message in <a href=https://github.com/cucumber/messages>Cucumber's message protocol</a>
+ * <p>
  * A step
  */
 // Generated code

--- a/java/src/generated/java/io/cucumber/messages/types/StepDefinition.java
+++ b/java/src/generated/java/io/cucumber/messages/types/StepDefinition.java
@@ -8,8 +8,7 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Represents the StepDefinition message in Cucumber's message protocol
- * @see <a href=https://github.com/cucumber/messages>Github - Cucumber - Messages</a>
+ * Represents the StepDefinition message in <a href=https://github.com/cucumber/messages>Cucumber's message protocol</a>
  */
 // Generated code
 @SuppressWarnings("unused")

--- a/java/src/generated/java/io/cucumber/messages/types/StepDefinitionPattern.java
+++ b/java/src/generated/java/io/cucumber/messages/types/StepDefinitionPattern.java
@@ -8,8 +8,7 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Represents the StepDefinitionPattern message in Cucumber's message protocol
- * @see <a href=https://github.com/cucumber/messages>Github - Cucumber - Messages</a>
+ * Represents the StepDefinitionPattern message in <a href=https://github.com/cucumber/messages>Cucumber's message protocol</a>
  */
 // Generated code
 @SuppressWarnings("unused")

--- a/java/src/generated/java/io/cucumber/messages/types/StepMatchArgument.java
+++ b/java/src/generated/java/io/cucumber/messages/types/StepMatchArgument.java
@@ -8,14 +8,13 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Represents the StepMatchArgument message in Cucumber's message protocol
- * @see <a href=https://github.com/cucumber/messages>Github - Cucumber - Messages</a>
- *
+ * Represents the StepMatchArgument message in <a href=https://github.com/cucumber/messages>Cucumber's message protocol</a>
+ * <p>
  * Represents a single argument extracted from a step match and passed to a step definition.
  * This is used for the following purposes:
  * - Construct an argument to pass to a step definition (possibly through a parameter type transform)
  * - Highlight the matched parameter in rich formatters such as the HTML formatter
- *
+ * <p>
  * This message closely matches the `Argument` class in the `cucumber-expressions` library.
  */
 // Generated code

--- a/java/src/generated/java/io/cucumber/messages/types/StepMatchArgumentsList.java
+++ b/java/src/generated/java/io/cucumber/messages/types/StepMatchArgumentsList.java
@@ -8,8 +8,7 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Represents the StepMatchArgumentsList message in Cucumber's message protocol
- * @see <a href=https://github.com/cucumber/messages>Github - Cucumber - Messages</a>
+ * Represents the StepMatchArgumentsList message in <a href=https://github.com/cucumber/messages>Cucumber's message protocol</a>
  */
 // Generated code
 @SuppressWarnings("unused")

--- a/java/src/generated/java/io/cucumber/messages/types/TableCell.java
+++ b/java/src/generated/java/io/cucumber/messages/types/TableCell.java
@@ -8,9 +8,8 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Represents the TableCell message in Cucumber's message protocol
- * @see <a href=https://github.com/cucumber/messages>Github - Cucumber - Messages</a>
- *
+ * Represents the TableCell message in <a href=https://github.com/cucumber/messages>Cucumber's message protocol</a>
+ * <p>
  * A cell in a `TableRow`
  */
 // Generated code

--- a/java/src/generated/java/io/cucumber/messages/types/TableRow.java
+++ b/java/src/generated/java/io/cucumber/messages/types/TableRow.java
@@ -8,9 +8,8 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Represents the TableRow message in Cucumber's message protocol
- * @see <a href=https://github.com/cucumber/messages>Github - Cucumber - Messages</a>
- *
+ * Represents the TableRow message in <a href=https://github.com/cucumber/messages>Cucumber's message protocol</a>
+ * <p>
  * A row in a table
  */
 // Generated code

--- a/java/src/generated/java/io/cucumber/messages/types/Tag.java
+++ b/java/src/generated/java/io/cucumber/messages/types/Tag.java
@@ -8,9 +8,8 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Represents the Tag message in Cucumber's message protocol
- * @see <a href=https://github.com/cucumber/messages>Github - Cucumber - Messages</a>
- *
+ * Represents the Tag message in <a href=https://github.com/cucumber/messages>Cucumber's message protocol</a>
+ * <p>
  * A tag
  */
 // Generated code

--- a/java/src/generated/java/io/cucumber/messages/types/TestCase.java
+++ b/java/src/generated/java/io/cucumber/messages/types/TestCase.java
@@ -8,11 +8,8 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Represents the TestCase message in Cucumber's message protocol
- * @see <a href=https://github.com/cucumber/messages>Github - Cucumber - Messages</a>
- *
- * //// TestCases
- *
+ * Represents the TestCase message in <a href=https://github.com/cucumber/messages>Cucumber's message protocol</a>
+ * <p>
  * A `TestCase` contains a sequence of `TestStep`s.
  */
 // Generated code

--- a/java/src/generated/java/io/cucumber/messages/types/TestCaseFinished.java
+++ b/java/src/generated/java/io/cucumber/messages/types/TestCaseFinished.java
@@ -8,8 +8,7 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Represents the TestCaseFinished message in Cucumber's message protocol
- * @see <a href=https://github.com/cucumber/messages>Github - Cucumber - Messages</a>
+ * Represents the TestCaseFinished message in <a href=https://github.com/cucumber/messages>Cucumber's message protocol</a>
  */
 // Generated code
 @SuppressWarnings("unused")

--- a/java/src/generated/java/io/cucumber/messages/types/TestCaseStarted.java
+++ b/java/src/generated/java/io/cucumber/messages/types/TestCaseStarted.java
@@ -8,8 +8,7 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Represents the TestCaseStarted message in Cucumber's message protocol
- * @see <a href=https://github.com/cucumber/messages>Github - Cucumber - Messages</a>
+ * Represents the TestCaseStarted message in <a href=https://github.com/cucumber/messages>Cucumber's message protocol</a>
  */
 // Generated code
 @SuppressWarnings("unused")

--- a/java/src/generated/java/io/cucumber/messages/types/TestRunFinished.java
+++ b/java/src/generated/java/io/cucumber/messages/types/TestRunFinished.java
@@ -8,8 +8,7 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Represents the TestRunFinished message in Cucumber's message protocol
- * @see <a href=https://github.com/cucumber/messages>Github - Cucumber - Messages</a>
+ * Represents the TestRunFinished message in <a href=https://github.com/cucumber/messages>Cucumber's message protocol</a>
  */
 // Generated code
 @SuppressWarnings("unused")

--- a/java/src/generated/java/io/cucumber/messages/types/TestRunHookFinished.java
+++ b/java/src/generated/java/io/cucumber/messages/types/TestRunHookFinished.java
@@ -8,8 +8,7 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Represents the TestRunHookFinished message in Cucumber's message protocol
- * @see <a href=https://github.com/cucumber/messages>Github - Cucumber - Messages</a>
+ * Represents the TestRunHookFinished message in <a href=https://github.com/cucumber/messages>Cucumber's message protocol</a>
  */
 // Generated code
 @SuppressWarnings("unused")

--- a/java/src/generated/java/io/cucumber/messages/types/TestRunHookStarted.java
+++ b/java/src/generated/java/io/cucumber/messages/types/TestRunHookStarted.java
@@ -8,8 +8,7 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Represents the TestRunHookStarted message in Cucumber's message protocol
- * @see <a href=https://github.com/cucumber/messages>Github - Cucumber - Messages</a>
+ * Represents the TestRunHookStarted message in <a href=https://github.com/cucumber/messages>Cucumber's message protocol</a>
  */
 // Generated code
 @SuppressWarnings("unused")

--- a/java/src/generated/java/io/cucumber/messages/types/TestRunStarted.java
+++ b/java/src/generated/java/io/cucumber/messages/types/TestRunStarted.java
@@ -8,8 +8,7 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Represents the TestRunStarted message in Cucumber's message protocol
- * @see <a href=https://github.com/cucumber/messages>Github - Cucumber - Messages</a>
+ * Represents the TestRunStarted message in <a href=https://github.com/cucumber/messages>Cucumber's message protocol</a>
  */
 // Generated code
 @SuppressWarnings("unused")

--- a/java/src/generated/java/io/cucumber/messages/types/TestStep.java
+++ b/java/src/generated/java/io/cucumber/messages/types/TestStep.java
@@ -8,9 +8,8 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Represents the TestStep message in Cucumber's message protocol
- * @see <a href=https://github.com/cucumber/messages>Github - Cucumber - Messages</a>
- *
+ * Represents the TestStep message in <a href=https://github.com/cucumber/messages>Cucumber's message protocol</a>
+ * <p>
  * A `TestStep` is derived from either a `PickleStep`
  * combined with a `StepDefinition`, or from a `Hook`.
  */

--- a/java/src/generated/java/io/cucumber/messages/types/TestStepFinished.java
+++ b/java/src/generated/java/io/cucumber/messages/types/TestStepFinished.java
@@ -8,8 +8,7 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Represents the TestStepFinished message in Cucumber's message protocol
- * @see <a href=https://github.com/cucumber/messages>Github - Cucumber - Messages</a>
+ * Represents the TestStepFinished message in <a href=https://github.com/cucumber/messages>Cucumber's message protocol</a>
  */
 // Generated code
 @SuppressWarnings("unused")

--- a/java/src/generated/java/io/cucumber/messages/types/TestStepResult.java
+++ b/java/src/generated/java/io/cucumber/messages/types/TestStepResult.java
@@ -8,8 +8,7 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Represents the TestStepResult message in Cucumber's message protocol
- * @see <a href=https://github.com/cucumber/messages>Github - Cucumber - Messages</a>
+ * Represents the TestStepResult message in <a href=https://github.com/cucumber/messages>Cucumber's message protocol</a>
  */
 // Generated code
 @SuppressWarnings("unused")

--- a/java/src/generated/java/io/cucumber/messages/types/TestStepStarted.java
+++ b/java/src/generated/java/io/cucumber/messages/types/TestStepStarted.java
@@ -8,8 +8,7 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Represents the TestStepStarted message in Cucumber's message protocol
- * @see <a href=https://github.com/cucumber/messages>Github - Cucumber - Messages</a>
+ * Represents the TestStepStarted message in <a href=https://github.com/cucumber/messages>Cucumber's message protocol</a>
  */
 // Generated code
 @SuppressWarnings("unused")

--- a/java/src/generated/java/io/cucumber/messages/types/Timestamp.java
+++ b/java/src/generated/java/io/cucumber/messages/types/Timestamp.java
@@ -8,8 +8,7 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Represents the Timestamp message in Cucumber's message protocol
- * @see <a href=https://github.com/cucumber/messages>Github - Cucumber - Messages</a>
+ * Represents the Timestamp message in <a href=https://github.com/cucumber/messages>Cucumber's message protocol</a>
  */
 // Generated code
 @SuppressWarnings("unused")

--- a/java/src/generated/java/io/cucumber/messages/types/UndefinedParameterType.java
+++ b/java/src/generated/java/io/cucumber/messages/types/UndefinedParameterType.java
@@ -8,8 +8,7 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Represents the UndefinedParameterType message in Cucumber's message protocol
- * @see <a href=https://github.com/cucumber/messages>Github - Cucumber - Messages</a>
+ * Represents the UndefinedParameterType message in <a href=https://github.com/cucumber/messages>Cucumber's message protocol</a>
  */
 // Generated code
 @SuppressWarnings("unused")

--- a/jsonschema/src/Attachment.json
+++ b/jsonschema/src/Attachment.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "Attachment.json",
   "additionalProperties": false,
-  "description": "//// Attachments (parse errors, execution errors, screenshots, links...)\n\n*\n An attachment represents any kind of data associated with a line in a\n [Source](#io.cucumber.messages.Source) file. It can be used for:\n\n * Syntax errors during parse time\n * Screenshots captured and attached during execution\n * Logs captured and attached during execution\n\n It is not to be used for runtime errors raised/thrown during execution. This\n is captured in `TestResult`.",
+  "description": "Attachments (parse errors, execution errors, screenshots, links...)\n\nAn attachment represents any kind of data associated with a line in a\n[Source](#io.cucumber.messages.Source) file. It can be used for:\n\n* Syntax errors during parse time\n* Screenshots captured and attached during execution\n* Logs captured and attached during execution\n\nIt is not to be used for runtime errors raised/thrown during execution. This\nis captured in `TestResult`.",
   "required": [
     "body",
     "contentEncoding",
@@ -10,11 +10,11 @@
   ],
   "properties": {
     "body": {
-      "description": "*\n The body of the attachment. If `contentEncoding` is `IDENTITY`, the attachment\n is simply the string. If it's `BASE64`, the string should be Base64 decoded to\n obtain the attachment.",
+      "description": "The body of the attachment. If `contentEncoding` is `IDENTITY`, the attachment\nis simply the string. If it's `BASE64`, the string should be Base64 decoded to\nobtain the attachment.",
       "type": "string"
     },
     "contentEncoding": {
-      "description": "*\n Whether to interpret `body` \"as-is\" (IDENTITY) or if it needs to be Base64-decoded (BASE64).\n\n Content encoding is *not* determined by the media type, but rather by the type\n of the object being attached:\n\n - string: IDENTITY\n - byte array: BASE64\n - stream: BASE64",
+      "description": "Whether to interpret `body` \"as-is\" (IDENTITY) or if it needs to be Base64-decoded (BASE64).\n\nContent encoding is *not* determined by the media type, but rather by the type\nof the object being attached:\n\n- string: IDENTITY\n- byte array: BASE64\n- stream: BASE64",
       "enum": [
         "IDENTITY",
         "BASE64"
@@ -22,11 +22,11 @@
       "type": "string"
     },
     "fileName": {
-      "description": "*\n Suggested file name of the attachment. (Provided by the user as an argument to `attach`)",
+      "description": "Suggested file name of the attachment. (Provided by the user as an argument to `attach`)",
       "type": "string"
     },
     "mediaType": {
-      "description": "*\n The media type of the data. This can be any valid\n [IANA Media Type](https://www.iana.org/assignments/media-types/media-types.xhtml)\n as well as Cucumber-specific media types such as `text/x.cucumber.gherkin+plain`\n and `text/x.cucumber.stacktrace+plain`",
+      "description": "The media type of the data. This can be any valid\n[IANA Media Type](https://www.iana.org/assignments/media-types/media-types.xhtml)\nas well as Cucumber-specific media types such as `text/x.cucumber.gherkin+plain`\nand `text/x.cucumber.stacktrace+plain`",
       "type": "string"
     },
     "source": {
@@ -41,7 +41,7 @@
       "type": "string"
     },
     "url": {
-      "description": "*\n A URL where the attachment can be retrieved. This field should not be set by Cucumber.\n It should be set by a program that reads a message stream and does the following for\n each Attachment message:\n\n - Writes the body (after base64 decoding if necessary) to a new file.\n - Sets `body` and `contentEncoding` to `null`\n - Writes out the new attachment message\n\n This will result in a smaller message stream, which can improve performance and\n reduce bandwidth of message consumers. It also makes it easier to process and download attachments\n separately from reports.",
+      "description": "A URL where the attachment can be retrieved. This field should not be set by Cucumber.\nIt should be set by a program that reads a message stream and does the following for\neach Attachment message:\n\n- Writes the body (after base64 decoding if necessary) to a new file.\n- Sets `body` and `contentEncoding` to `null`\n- Writes out the new attachment message\n\nThis will result in a smaller message stream, which can improve performance and\nreduce bandwidth of message consumers. It also makes it easier to process and download attachments\nseparately from reports.",
       "type": "string"
     },
     "testRunStartedId": {

--- a/jsonschema/src/Duration.json
+++ b/jsonschema/src/Duration.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "Duration.json",
   "additionalProperties": false,
-  "description": "The structure is pretty close of the Timestamp one. For clarity, a second type\n of message is used.",
+  "description": "The structure is pretty close of the Timestamp one. For clarity, a second type\nof message is used.",
   "required": [
     "seconds",
     "nanos"
@@ -12,7 +12,7 @@
       "type": "integer"
     },
     "nanos": {
-      "description": "Non-negative fractions of a second at nanosecond resolution. Negative\n second values with fractions must still have non-negative nanos values\n that count forward in time. Must be from 0 to 999,999,999\n inclusive.",
+      "description": "Non-negative fractions of a second at nanosecond resolution. Negative\nsecond values with fractions must still have non-negative nanos values\nthat count forward in time. Must be from 0 to 999,999,999\ninclusive.",
       "type": "integer"
     }
   },

--- a/jsonschema/src/Envelope.json
+++ b/jsonschema/src/Envelope.json
@@ -2,7 +2,6 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "Envelope.json",
   "additionalProperties": false,
-  "description": "When removing a field, replace it with reserved, rather than deleting the line.\n When adding a field, add it to the end and increment the number by one.\n See https://developers.google.com/protocol-buffers/docs/proto#updating for details\n\n*\n All the messages that are passed between different components/processes are Envelope\n messages.",
   "properties": {
     "attachment": {
       "$ref": "./Attachment.json"

--- a/jsonschema/src/GherkinDocument.json
+++ b/jsonschema/src/GherkinDocument.json
@@ -44,7 +44,7 @@
     "Comment": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": false,
-      "description": "*\n A comment in a Gherkin document",
+      "description": "A comment in a Gherkin document",
       "required": [
         "location",
         "text"
@@ -204,7 +204,7 @@
     "FeatureChild": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": false,
-      "description": "*\n A child node of a `Feature` node",
+      "description": "A child node of a `Feature` node",
       "properties": {
         "rule": {
           "$ref": "#/definitions/Rule"
@@ -266,7 +266,7 @@
     "RuleChild": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": false,
-      "description": "*\n A child node of a `Rule` node",
+      "description": "A child node of a `Rule` node",
       "properties": {
         "background": {
           "$ref": "#/definitions/Background"
@@ -428,7 +428,7 @@
     "Tag": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": false,
-      "description": "*\n A tag",
+      "description": "A tag",
       "required": [
         "location",
         "name",
@@ -451,13 +451,13 @@
       "type": "object"
     }
   },
-  "description": "*\n The [AST](https://en.wikipedia.org/wiki/Abstract_syntax_tree) of a Gherkin document.\n Cucumber implementations should *not* depend on `GherkinDocument` or any of its\n children for execution - use [Pickle](#io.cucumber.messages.Pickle) instead.\n\n The only consumers of `GherkinDocument` should only be formatters that produce\n \"rich\" output, resembling the original Gherkin document.",
+  "description": "The [AST](https://en.wikipedia.org/wiki/Abstract_syntax_tree) of a Gherkin document.\nCucumber implementations should *not* depend on `GherkinDocument` or any of its\nchildren for execution - use [Pickle](#io.cucumber.messages.Pickle) instead.\n\nThe only consumers of `GherkinDocument` should only be formatters that produce\n\"rich\" output, resembling the original Gherkin document.",
   "required": [
     "comments"
   ],
   "properties": {
     "uri": {
-      "description": "*\n The [URI](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier)\n of the source, typically a file path relative to the root directory",
+      "description": "The [URI](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier)\nof the source, typically a file path relative to the root directory",
       "type": "string"
     },
     "feature": {

--- a/jsonschema/src/Location.json
+++ b/jsonschema/src/Location.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "Location.json",
   "additionalProperties": false,
-  "description": "*\n Points to a line and a column in a text file",
+  "description": "Points to a line and a column in a text file",
   "properties": {
     "line": {
       "type": "integer"

--- a/jsonschema/src/Meta.json
+++ b/jsonschema/src/Meta.json
@@ -30,7 +30,7 @@
     },
     "Git": {
       "additionalProperties": false,
-      "description": "Information about Git, provided by the Build/CI server as environment\n variables.",
+      "description": "Information about Git, provided by the Build/CI server as environment\nvariables.",
       "required": [
         "remote",
         "revision"
@@ -71,7 +71,7 @@
       "type": "object"
     }
   },
-  "description": "*\n This message contains meta information about the environment. Consumers can use\n this for various purposes.",
+  "description": "This message contains meta information about the environment. Consumers can use\nthis for various purposes.",
   "required": [
     "protocolVersion",
     "implementation",
@@ -81,7 +81,7 @@
   ],
   "properties": {
     "protocolVersion": {
-      "description": "*\n The [SEMVER](https://semver.org/) version number of the protocol",
+      "description": "The [SEMVER](https://semver.org/) version number of the protocol",
       "type": "string"
     },
     "implementation": {

--- a/jsonschema/src/Pickle.json
+++ b/jsonschema/src/Pickle.json
@@ -21,7 +21,7 @@
     "PickleStep": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": false,
-      "description": "*\n An executable step",
+      "description": "An executable step",
       "required": [
         "astNodeIds",
         "id",
@@ -32,7 +32,7 @@
           "$ref": "#/definitions/PickleStepArgument"
         },
         "astNodeIds": {
-          "description": "References the IDs of the source of the step. For Gherkin, this can be\n the ID of a Step, and possibly also the ID of a TableRow",
+          "description": "References the IDs of the source of the step. For Gherkin, this can be\nthe ID of a Step, and possibly also the ID of a TableRow",
           "items": {
             "type": "string"
           },
@@ -120,7 +120,7 @@
     "PickleTag": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": false,
-      "description": "*\n A tag",
+      "description": "A tag",
       "required": [
         "name",
         "astNodeId"
@@ -137,7 +137,7 @@
       "type": "object"
     }
   },
-  "description": "//// Pickles\n\n*\n A `Pickle` represents a template for a `TestCase`. It is typically derived\n from another format, such as [GherkinDocument](#io.cucumber.messages.GherkinDocument).\n In the future a `Pickle` may be derived from other formats such as Markdown or\n Excel files.\n\n By making `Pickle` the main data structure Cucumber uses for execution, the\n implementation of Cucumber itself becomes simpler, as it doesn't have to deal\n with the complex structure of a [GherkinDocument](#io.cucumber.messages.GherkinDocument).\n\n Each `PickleStep` of a `Pickle` is matched with a `StepDefinition` to create a `TestCase`",
+  "description": "A `Pickle` represents a template for a `TestCase`. It is typically derived\nfrom another format, such as [GherkinDocument](#io.cucumber.messages.GherkinDocument).\nIn the future a `Pickle` may be derived from other formats such as Markdown or\nExcel files.\n\nBy making `Pickle` the main data structure Cucumber uses for execution, the\nimplementation of Cucumber itself becomes simpler, as it doesn't have to deal\nwith the complex structure of a [GherkinDocument](#io.cucumber.messages.GherkinDocument).\n\nEach `PickleStep` of a `Pickle` is matched with a `StepDefinition` to create a `TestCase`",
   "required": [
     "id",
     "uri",
@@ -149,7 +149,7 @@
   ],
   "properties": {
     "id": {
-      "description": "*\n A unique id for the pickle",
+      "description": "A unique id for the pickle",
       "type": "string"
     },
     "uri": {
@@ -172,14 +172,14 @@
       "type": "array"
     },
     "tags": {
-      "description": "*\n One or more tags. If this pickle is constructed from a Gherkin document,\n It includes inherited tags from the `Feature` as well.",
+      "description": "One or more tags. If this pickle is constructed from a Gherkin document,\nIt includes inherited tags from the `Feature` as well.",
       "items": {
         "$ref": "#/definitions/PickleTag"
       },
       "type": "array"
     },
     "astNodeIds": {
-      "description": "*\n Points to the AST node locations of the pickle. The last one represents the unique\n id of the pickle. A pickle constructed from `Examples` will have the first\n id originating from the `Scenario` AST node, and the second from the `TableRow` AST node.",
+      "description": "Points to the AST node locations of the pickle. The last one represents the unique\nid of the pickle. A pickle constructed from `Examples` will have the first\nid originating from the `Scenario` AST node, and the second from the `TableRow` AST node.",
       "items": {
         "type": "string"
       },

--- a/jsonschema/src/Source.json
+++ b/jsonschema/src/Source.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "Source.json",
   "additionalProperties": false,
-  "description": "//// Source\n\n*\n A source file, typically a Gherkin document or Java/Ruby/JavaScript source code",
+  "description": "A source file, typically a Gherkin document or Java/Ruby/JavaScript source code",
   "required": [
     "uri",
     "data",
@@ -10,7 +10,7 @@
   ],
   "properties": {
     "uri": {
-      "description": "*\n The [URI](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier)\n of the source, typically a file path relative to the root directory",
+      "description": "The [URI](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier)\nof the source, typically a file path relative to the root directory",
       "type": "string"
     },
     "data": {
@@ -18,7 +18,7 @@
       "type": "string"
     },
     "mediaType": {
-      "description": "The media type of the file. Can be used to specify custom types, such as\n text/x.cucumber.gherkin+plain",
+      "description": "The media type of the file. Can be used to specify custom types, such as\ntext/x.cucumber.gherkin+plain",
       "type": "string",
       "enum": [
         "text/x.cucumber.gherkin+plain",

--- a/jsonschema/src/SourceReference.json
+++ b/jsonschema/src/SourceReference.json
@@ -47,7 +47,7 @@
       "type": "object"
     }
   },
-  "description": "*\n Points to a [Source](#io.cucumber.messages.Source) identified by `uri` and a\n [Location](#io.cucumber.messages.Location) within that file.",
+  "description": "Points to a [Source](#io.cucumber.messages.Source) identified by `uri` and a\n[Location](#io.cucumber.messages.Location) within that file.",
   "properties": {
     "uri": {
       "type": "string"

--- a/jsonschema/src/TestCase.json
+++ b/jsonschema/src/TestCase.json
@@ -29,14 +29,14 @@
     "StepMatchArgument": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": false,
-      "description": "*\n Represents a single argument extracted from a step match and passed to a step definition.\n This is used for the following purposes:\n - Construct an argument to pass to a step definition (possibly through a parameter type transform)\n - Highlight the matched parameter in rich formatters such as the HTML formatter\n\n This message closely matches the `Argument` class in the `cucumber-expressions` library.",
+      "description": "Represents a single argument extracted from a step match and passed to a step definition.\nThis is used for the following purposes:\n- Construct an argument to pass to a step definition (possibly through a parameter type transform)\n- Highlight the matched parameter in rich formatters such as the HTML formatter\n\nThis message closely matches the `Argument` class in the `cucumber-expressions` library.",
       "required": [
         "group"
       ],
       "properties": {
         "group": {
           "$ref": "#/definitions/Group",
-          "description": "*\n Represents the outermost capture group of an argument. This message closely matches the\n `Group` class in the `cucumber-expressions` library."
+          "description": "Represents the outermost capture group of an argument. This message closely matches the\n`Group` class in the `cucumber-expressions` library."
         },
         "parameterTypeName": {
           "type": "string"
@@ -63,7 +63,7 @@
     "TestStep": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": false,
-      "description": "*\n A `TestStep` is derived from either a `PickleStep`\n combined with a `StepDefinition`, or from a `Hook`.",
+      "description": "A `TestStep` is derived from either a `PickleStep`\ncombined with a `StepDefinition`, or from a `Hook`.",
       "required": [
         "id"
       ],
@@ -80,7 +80,7 @@
           "type": "string"
         },
         "stepDefinitionIds": {
-          "description": "Pointer to all the matching `StepDefinition`s (if derived from a `PickleStep`)\n Each element represents a matching step definition. A size of 0 means `UNDEFINED`,\n and a size of 2+ means `AMBIGUOUS`",
+          "description": "Pointer to all the matching `StepDefinition`s (if derived from a `PickleStep`)\nEach element represents a matching step definition. A size of 0 means `UNDEFINED`,\nand a size of 2+ means `AMBIGUOUS`",
           "items": {
             "type": "string"
           },
@@ -97,7 +97,7 @@
       "type": "object"
     }
   },
-  "description": "//// TestCases\n\n*\n A `TestCase` contains a sequence of `TestStep`s.",
+  "description": "A `TestCase` contains a sequence of `TestStep`s.",
   "required": [
     "id",
     "pickleId",

--- a/jsonschema/src/TestCaseStarted.json
+++ b/jsonschema/src/TestCaseStarted.json
@@ -10,11 +10,11 @@
   ],
   "properties": {
     "attempt": {
-      "description": "*\n The first attempt should have value 0, and for each retry the value\n should increase by 1.",
+      "description": "The first attempt should have value 0, and for each retry the value\nshould increase by 1.",
       "type": "integer"
     },
     "id": {
-      "description": "*\n Because a `TestCase` can be run multiple times (in case of a retry),\n we use this field to group messages relating to the same attempt.",
+      "description": "Because a `TestCase` can be run multiple times (in case of a retry),\nwe use this field to group messages relating to the same attempt.",
       "type": "string"
     },
     "testCaseId": {

--- a/jsonschema/src/Timestamp.json
+++ b/jsonschema/src/Timestamp.json
@@ -8,11 +8,11 @@
   ],
   "properties": {
     "seconds": {
-      "description": "Represents seconds of UTC time since Unix epoch\n 1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to\n 9999-12-31T23:59:59Z inclusive.",
+      "description": "Represents seconds of UTC time since Unix epoch\n1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to\n9999-12-31T23:59:59Z inclusive.",
       "type": "integer"
     },
     "nanos": {
-      "description": "Non-negative fractions of a second at nanosecond resolution. Negative\n second values with fractions must still have non-negative nanos values\n that count forward in time. Must be from 0 to 999,999,999\n inclusive.",
+      "description": "Non-negative fractions of a second at nanosecond resolution. Negative\nsecond values with fractions must still have non-negative nanos values\nthat count forward in time. Must be from 0 to 999,999,999\ninclusive.",
       "type": "integer"
     }
   },

--- a/perl/lib/Cucumber/Messages.pm
+++ b/perl/lib/Cucumber/Messages.pm
@@ -55,18 +55,17 @@ package Cucumber::Messages::Attachment {
 Represents the Attachment message in Cucumber's
 L<message protocol|https://github.com/cucumber/messages>.
 
-//// Attachments (parse errors, execution errors, screenshots, links...)
+Attachments (parse errors, execution errors, screenshots, links...)
 
-*
- An attachment represents any kind of data associated with a line in a
- [Source](#io.cucumber.messages.Source) file. It can be used for:
+An attachment represents any kind of data associated with a line in a
+[Source](#io.cucumber.messages.Source) file. It can be used for:
 
- * Syntax errors during parse time
- * Screenshots captured and attached during execution
- * Logs captured and attached during execution
+* Syntax errors during parse time
+* Screenshots captured and attached during execution
+* Logs captured and attached during execution
 
- It is not to be used for runtime errors raised/thrown during execution. This
- is captured in `TestResult`.
+It is not to be used for runtime errors raised/thrown during execution. This
+is captured in `TestResult`.
 
 =head3 ATTRIBUTES
 
@@ -101,10 +100,9 @@ sub _types {
 
 =head4 body
 
-*
- The body of the attachment. If `contentEncoding` is `IDENTITY`, the attachment
- is simply the string. If it's `BASE64`, the string should be Base64 decoded to
- obtain the attachment.
+The body of the attachment. If `contentEncoding` is `IDENTITY`, the attachment
+is simply the string. If it's `BASE64`, the string should be Base64 decoded to
+obtain the attachment.
 =cut
 
 has body =>
@@ -116,15 +114,14 @@ has body =>
 
 =head4 content_encoding
 
-*
- Whether to interpret `body` "as-is" (IDENTITY) or if it needs to be Base64-decoded (BASE64).
+Whether to interpret `body` "as-is" (IDENTITY) or if it needs to be Base64-decoded (BASE64).
 
- Content encoding is *not* determined by the media type, but rather by the type
- of the object being attached:
+Content encoding is *not* determined by the media type, but rather by the type
+of the object being attached:
 
- - string: IDENTITY
- - byte array: BASE64
- - stream: BASE64
+- string: IDENTITY
+- byte array: BASE64
+- stream: BASE64
 
 Available constants for valid values of this field:
 
@@ -153,8 +150,7 @@ has content_encoding =>
 
 =head4 file_name
 
-*
- Suggested file name of the attachment. (Provided by the user as an argument to `attach`)
+Suggested file name of the attachment. (Provided by the user as an argument to `attach`)
 =cut
 
 has file_name =>
@@ -164,11 +160,10 @@ has file_name =>
 
 =head4 media_type
 
-*
- The media type of the data. This can be any valid
- [IANA Media Type](https://www.iana.org/assignments/media-types/media-types.xhtml)
- as well as Cucumber-specific media types such as `text/x.cucumber.gherkin+plain`
- and `text/x.cucumber.stacktrace+plain`
+The media type of the data. This can be any valid
+[IANA Media Type](https://www.iana.org/assignments/media-types/media-types.xhtml)
+as well as Cucumber-specific media types such as `text/x.cucumber.gherkin+plain`
+and `text/x.cucumber.stacktrace+plain`
 =cut
 
 has media_type =>
@@ -210,18 +205,17 @@ has test_step_id =>
 
 =head4 url
 
-*
- A URL where the attachment can be retrieved. This field should not be set by Cucumber.
- It should be set by a program that reads a message stream and does the following for
- each Attachment message:
+A URL where the attachment can be retrieved. This field should not be set by Cucumber.
+It should be set by a program that reads a message stream and does the following for
+each Attachment message:
 
- - Writes the body (after base64 decoding if necessary) to a new file.
- - Sets `body` and `contentEncoding` to `null`
- - Writes out the new attachment message
+- Writes the body (after base64 decoding if necessary) to a new file.
+- Sets `body` and `contentEncoding` to `null`
+- Writes out the new attachment message
 
- This will result in a smaller message stream, which can improve performance and
- reduce bandwidth of message consumers. It also makes it easier to process and download attachments
- separately from reports.
+This will result in a smaller message stream, which can improve performance and
+reduce bandwidth of message consumers. It also makes it easier to process and download attachments
+separately from reports.
 =cut
 
 has url =>
@@ -271,7 +265,7 @@ Represents the Duration message in Cucumber's
 L<message protocol|https://github.com/cucumber/messages>.
 
 The structure is pretty close of the Timestamp one. For clarity, a second type
- of message is used.
+of message is used.
 
 =head3 ATTRIBUTES
 
@@ -310,9 +304,9 @@ has seconds =>
 =head4 nanos
 
 Non-negative fractions of a second at nanosecond resolution. Negative
- second values with fractions must still have non-negative nanos values
- that count forward in time. Must be from 0 to 999,999,999
- inclusive.
+second values with fractions must still have non-negative nanos values
+that count forward in time. Must be from 0 to 999,999,999
+inclusive.
 =cut
 
 has nanos =>
@@ -333,13 +327,7 @@ package Cucumber::Messages::Envelope {
 Represents the Envelope message in Cucumber's
 L<message protocol|https://github.com/cucumber/messages>.
 
-When removing a field, replace it with reserved, rather than deleting the line.
- When adding a field, add it to the end and increment the number by one.
- See https://developers.google.com/protocol-buffers/docs/proto#updating for details
 
-*
- All the messages that are passed between different components/processes are Envelope
- messages.
 
 =head3 ATTRIBUTES
 
@@ -649,13 +637,12 @@ package Cucumber::Messages::GherkinDocument {
 Represents the GherkinDocument message in Cucumber's
 L<message protocol|https://github.com/cucumber/messages>.
 
-*
- The [AST](https://en.wikipedia.org/wiki/Abstract_syntax_tree) of a Gherkin document.
- Cucumber implementations should *not* depend on `GherkinDocument` or any of its
- children for execution - use [Pickle](#io.cucumber.messages.Pickle) instead.
+The [AST](https://en.wikipedia.org/wiki/Abstract_syntax_tree) of a Gherkin document.
+Cucumber implementations should *not* depend on `GherkinDocument` or any of its
+children for execution - use [Pickle](#io.cucumber.messages.Pickle) instead.
 
- The only consumers of `GherkinDocument` should only be formatters that produce
- "rich" output, resembling the original Gherkin document.
+The only consumers of `GherkinDocument` should only be formatters that produce
+"rich" output, resembling the original Gherkin document.
 
 =head3 ATTRIBUTES
 
@@ -682,9 +669,8 @@ sub _types {
 
 =head4 uri
 
-*
- The [URI](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier)
- of the source, typically a file path relative to the root directory
+The [URI](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier)
+of the source, typically a file path relative to the root directory
 =cut
 
 has uri =>
@@ -836,8 +822,7 @@ package Cucumber::Messages::Comment {
 Represents the Comment message in Cucumber's
 L<message protocol|https://github.com/cucumber/messages>.
 
-*
- A comment in a Gherkin document
+A comment in a Gherkin document
 
 =head3 ATTRIBUTES
 
@@ -1297,8 +1282,7 @@ package Cucumber::Messages::FeatureChild {
 Represents the FeatureChild message in Cucumber's
 L<message protocol|https://github.com/cucumber/messages>.
 
-*
- A child node of a `Feature` node
+A child node of a `Feature` node
 
 =head3 ATTRIBUTES
 
@@ -1488,8 +1472,7 @@ package Cucumber::Messages::RuleChild {
 Represents the RuleChild message in Cucumber's
 L<message protocol|https://github.com/cucumber/messages>.
 
-*
- A child node of a `Rule` node
+A child node of a `Rule` node
 
 =head3 ATTRIBUTES
 
@@ -1956,8 +1939,7 @@ package Cucumber::Messages::Tag {
 Represents the Tag message in Cucumber's
 L<message protocol|https://github.com/cucumber/messages>.
 
-*
- A tag
+A tag
 
 =head3 ATTRIBUTES
 
@@ -2150,8 +2132,7 @@ package Cucumber::Messages::Location {
 Represents the Location message in Cucumber's
 L<message protocol|https://github.com/cucumber/messages>.
 
-*
- Points to a line and a column in a text file
+Points to a line and a column in a text file
 
 =head3 ATTRIBUTES
 
@@ -2208,9 +2189,8 @@ package Cucumber::Messages::Meta {
 Represents the Meta message in Cucumber's
 L<message protocol|https://github.com/cucumber/messages>.
 
-*
- This message contains meta information about the environment. Consumers can use
- this for various purposes.
+This message contains meta information about the environment. Consumers can use
+this for various purposes.
 
 =head3 ATTRIBUTES
 
@@ -2240,8 +2220,7 @@ sub _types {
 
 =head4 protocol_version
 
-*
- The [SEMVER](https://semver.org/) version number of the protocol
+The [SEMVER](https://semver.org/) version number of the protocol
 =cut
 
 has protocol_version =>
@@ -2400,7 +2379,7 @@ Represents the Git message in Cucumber's
 L<message protocol|https://github.com/cucumber/messages>.
 
 Information about Git, provided by the Build/CI server as environment
- variables.
+variables.
 
 =head3 ATTRIBUTES
 
@@ -2706,19 +2685,16 @@ package Cucumber::Messages::Pickle {
 Represents the Pickle message in Cucumber's
 L<message protocol|https://github.com/cucumber/messages>.
 
-//// Pickles
+A `Pickle` represents a template for a `TestCase`. It is typically derived
+from another format, such as [GherkinDocument](#io.cucumber.messages.GherkinDocument).
+In the future a `Pickle` may be derived from other formats such as Markdown or
+Excel files.
 
-*
- A `Pickle` represents a template for a `TestCase`. It is typically derived
- from another format, such as [GherkinDocument](#io.cucumber.messages.GherkinDocument).
- In the future a `Pickle` may be derived from other formats such as Markdown or
- Excel files.
+By making `Pickle` the main data structure Cucumber uses for execution, the
+implementation of Cucumber itself becomes simpler, as it doesn't have to deal
+with the complex structure of a [GherkinDocument](#io.cucumber.messages.GherkinDocument).
 
- By making `Pickle` the main data structure Cucumber uses for execution, the
- implementation of Cucumber itself becomes simpler, as it doesn't have to deal
- with the complex structure of a [GherkinDocument](#io.cucumber.messages.GherkinDocument).
-
- Each `PickleStep` of a `Pickle` is matched with a `StepDefinition` to create a `TestCase`
+Each `PickleStep` of a `Pickle` is matched with a `StepDefinition` to create a `TestCase`
 
 =head3 ATTRIBUTES
 
@@ -2749,8 +2725,7 @@ sub _types {
 
 =head4 id
 
-*
- A unique id for the pickle
+A unique id for the pickle
 =cut
 
 has id =>
@@ -2810,9 +2785,8 @@ has steps =>
 
 =head4 tags
 
-*
- One or more tags. If this pickle is constructed from a Gherkin document,
- It includes inherited tags from the `Feature` as well.
+One or more tags. If this pickle is constructed from a Gherkin document,
+It includes inherited tags from the `Feature` as well.
 =cut
 
 has tags =>
@@ -2824,10 +2798,9 @@ has tags =>
 
 =head4 ast_node_ids
 
-*
- Points to the AST node locations of the pickle. The last one represents the unique
- id of the pickle. A pickle constructed from `Examples` will have the first
- id originating from the `Scenario` AST node, and the second from the `TableRow` AST node.
+Points to the AST node locations of the pickle. The last one represents the unique
+id of the pickle. A pickle constructed from `Examples` will have the first
+id originating from the `Scenario` AST node, and the second from the `TableRow` AST node.
 =cut
 
 has ast_node_ids =>
@@ -2905,8 +2878,7 @@ package Cucumber::Messages::PickleStep {
 Represents the PickleStep message in Cucumber's
 L<message protocol|https://github.com/cucumber/messages>.
 
-*
- An executable step
+An executable step
 
 =head3 ATTRIBUTES
 
@@ -2946,7 +2918,7 @@ has argument =>
 =head4 ast_node_ids
 
 References the IDs of the source of the step. For Gherkin, this can be
- the ID of a Step, and possibly also the ID of a TableRow
+the ID of a Step, and possibly also the ID of a TableRow
 =cut
 
 has ast_node_ids =>
@@ -3219,8 +3191,7 @@ package Cucumber::Messages::PickleTag {
 Represents the PickleTag message in Cucumber's
 L<message protocol|https://github.com/cucumber/messages>.
 
-*
- A tag
+A tag
 
 =head3 ATTRIBUTES
 
@@ -3279,10 +3250,7 @@ package Cucumber::Messages::Source {
 Represents the Source message in Cucumber's
 L<message protocol|https://github.com/cucumber/messages>.
 
-//// Source
-
-*
- A source file, typically a Gherkin document or Java/Ruby/JavaScript source code
+A source file, typically a Gherkin document or Java/Ruby/JavaScript source code
 
 =head3 ATTRIBUTES
 
@@ -3309,9 +3277,8 @@ sub _types {
 
 =head4 uri
 
-*
- The [URI](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier)
- of the source, typically a file path relative to the root directory
+The [URI](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier)
+of the source, typically a file path relative to the root directory
 =cut
 
 has uri =>
@@ -3336,7 +3303,7 @@ has data =>
 =head4 media_type
 
 The media type of the file. Can be used to specify custom types, such as
- text/x.cucumber.gherkin+plain
+text/x.cucumber.gherkin+plain
 
 Available constants for valid values of this field:
 
@@ -3374,9 +3341,8 @@ package Cucumber::Messages::SourceReference {
 Represents the SourceReference message in Cucumber's
 L<message protocol|https://github.com/cucumber/messages>.
 
-*
- Points to a [Source](#io.cucumber.messages.Source) identified by `uri` and a
- [Location](#io.cucumber.messages.Location) within that file.
+Points to a [Source](#io.cucumber.messages.Source) identified by `uri` and a
+[Location](#io.cucumber.messages.Location) within that file.
 
 =head3 ATTRIBUTES
 
@@ -3745,10 +3711,7 @@ package Cucumber::Messages::TestCase {
 Represents the TestCase message in Cucumber's
 L<message protocol|https://github.com/cucumber/messages>.
 
-//// TestCases
-
-*
- A `TestCase` contains a sequence of `TestStep`s.
+A `TestCase` contains a sequence of `TestStep`s.
 
 =head3 ATTRIBUTES
 
@@ -3899,13 +3862,12 @@ package Cucumber::Messages::StepMatchArgument {
 Represents the StepMatchArgument message in Cucumber's
 L<message protocol|https://github.com/cucumber/messages>.
 
-*
- Represents a single argument extracted from a step match and passed to a step definition.
- This is used for the following purposes:
- - Construct an argument to pass to a step definition (possibly through a parameter type transform)
- - Highlight the matched parameter in rich formatters such as the HTML formatter
+Represents a single argument extracted from a step match and passed to a step definition.
+This is used for the following purposes:
+- Construct an argument to pass to a step definition (possibly through a parameter type transform)
+- Highlight the matched parameter in rich formatters such as the HTML formatter
 
- This message closely matches the `Argument` class in the `cucumber-expressions` library.
+This message closely matches the `Argument` class in the `cucumber-expressions` library.
 
 =head3 ATTRIBUTES
 
@@ -3931,9 +3893,8 @@ sub _types {
 
 =head4 group
 
-*
- Represents the outermost capture group of an argument. This message closely matches the
- `Group` class in the `cucumber-expressions` library.
+Represents the outermost capture group of an argument. This message closely matches the
+`Group` class in the `cucumber-expressions` library.
 =cut
 
 has group =>
@@ -4010,9 +3971,8 @@ package Cucumber::Messages::TestStep {
 Represents the TestStep message in Cucumber's
 L<message protocol|https://github.com/cucumber/messages>.
 
-*
- A `TestStep` is derived from either a `PickleStep`
- combined with a `StepDefinition`, or from a `Hook`.
+A `TestStep` is derived from either a `PickleStep`
+combined with a `StepDefinition`, or from a `Hook`.
 
 =head3 ATTRIBUTES
 
@@ -4074,8 +4034,8 @@ has pickle_step_id =>
 =head4 step_definition_ids
 
 Pointer to all the matching `StepDefinition`s (if derived from a `PickleStep`)
- Each element represents a matching step definition. A size of 0 means `UNDEFINED`,
- and a size of 2+ means `AMBIGUOUS`
+Each element represents a matching step definition. A size of 0 means `UNDEFINED`,
+and a size of 2+ means `AMBIGUOUS`
 =cut
 
 has step_definition_ids =>
@@ -4205,9 +4165,8 @@ sub _types {
 
 =head4 attempt
 
-*
- The first attempt should have value 0, and for each retry the value
- should increase by 1.
+The first attempt should have value 0, and for each retry the value
+should increase by 1.
 =cut
 
 has attempt =>
@@ -4219,9 +4178,8 @@ has attempt =>
 
 =head4 id
 
-*
- Because a `TestCase` can be run multiple times (in case of a retry),
- we use this field to group messages relating to the same attempt.
+Because a `TestCase` can be run multiple times (in case of a retry),
+we use this field to group messages relating to the same attempt.
 =cut
 
 has id =>
@@ -4879,8 +4837,8 @@ sub _types {
 =head4 seconds
 
 Represents seconds of UTC time since Unix epoch
- 1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
- 9999-12-31T23:59:59Z inclusive.
+1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
+9999-12-31T23:59:59Z inclusive.
 =cut
 
 has seconds =>
@@ -4893,9 +4851,9 @@ has seconds =>
 =head4 nanos
 
 Non-negative fractions of a second at nanosecond resolution. Negative
- second values with fractions must still have non-negative nanos values
- that count forward in time. Must be from 0 to 999,999,999
- inclusive.
+second values with fractions must still have non-negative nanos values
+that count forward in time. Must be from 0 to 999,999,999
+inclusive.
 =cut
 
 has nanos =>

--- a/php/src-generated/Attachment.php
+++ b/php/src-generated/Attachment.php
@@ -15,7 +15,7 @@ use Cucumber\Messages\DecodingException\SchemaViolationException;
  * Represents the Attachment message in Cucumber's message protocol
  * @see https://github.com/cucumber/messages
  *
- * //// Attachments (parse errors, execution errors, screenshots, links...)
+ * Attachments (parse errors, execution errors, screenshots, links...)
  *
  * An attachment represents any kind of data associated with a line in a
  * [Source](#io.cucumber.messages.Source) file. It can be used for:

--- a/php/src-generated/Envelope.php
+++ b/php/src-generated/Envelope.php
@@ -15,12 +15,7 @@ use Cucumber\Messages\DecodingException\SchemaViolationException;
  * Represents the Envelope message in Cucumber's message protocol
  * @see https://github.com/cucumber/messages
  *
- * When removing a field, replace it with reserved, rather than deleting the line.
- * When adding a field, add it to the end and increment the number by one.
- * See https://developers.google.com/protocol-buffers/docs/proto#updating for details
- *
- * All the messages that are passed between different components/processes are Envelope
- * messages. */
+ */
 final class Envelope implements JsonSerializable
 {
     use JsonEncodingTrait;

--- a/php/src-generated/Pickle.php
+++ b/php/src-generated/Pickle.php
@@ -15,8 +15,6 @@ use Cucumber\Messages\DecodingException\SchemaViolationException;
  * Represents the Pickle message in Cucumber's message protocol
  * @see https://github.com/cucumber/messages
  *
- * //// Pickles
- *
  * A `Pickle` represents a template for a `TestCase`. It is typically derived
  * from another format, such as [GherkinDocument](#io.cucumber.messages.GherkinDocument).
  * In the future a `Pickle` may be derived from other formats such as Markdown or

--- a/php/src-generated/Source.php
+++ b/php/src-generated/Source.php
@@ -15,8 +15,6 @@ use Cucumber\Messages\DecodingException\SchemaViolationException;
  * Represents the Source message in Cucumber's message protocol
  * @see https://github.com/cucumber/messages
  *
- * //// Source
- *
  * A source file, typically a Gherkin document or Java/Ruby/JavaScript source code */
 final class Source implements JsonSerializable
 {

--- a/php/src-generated/TestCase.php
+++ b/php/src-generated/TestCase.php
@@ -15,8 +15,6 @@ use Cucumber\Messages\DecodingException\SchemaViolationException;
  * Represents the TestCase message in Cucumber's message protocol
  * @see https://github.com/cucumber/messages
  *
- * //// TestCases
- *
  * A `TestCase` contains a sequence of `TestStep`s. */
 final class TestCase implements JsonSerializable
 {

--- a/python/src/cucumber_messages/_messages.py
+++ b/python/src/cucumber_messages/_messages.py
@@ -11,55 +11,46 @@ from ._message_enums import *
 @dataclass
 class Attachment:
     """
-    //// Attachments (parse errors, execution errors, screenshots, links...)
+    Attachments (parse errors, execution errors, screenshots, links...)
 
-    *
-     An attachment represents any kind of data associated with a line in a
-     [Source](#io.cucumber.messages.Source) file. It can be used for:
+    An attachment represents any kind of data associated with a line in a
+    [Source](#io.cucumber.messages.Source) file. It can be used for:
 
-     * Syntax errors during parse time
-     * Screenshots captured and attached during execution
-     * Logs captured and attached during execution
+    * Syntax errors during parse time
+    * Screenshots captured and attached during execution
+    * Logs captured and attached during execution
 
-     It is not to be used for runtime errors raised/thrown during execution. This
-     is captured in `TestResult`.
+    It is not to be used for runtime errors raised/thrown during execution. This
+    is captured in `TestResult`.
     """
     body: str
     """
-    *
-     The body of the attachment. If `contentEncoding` is `IDENTITY`, the attachment
-     is simply the string. If it's `BASE64`, the string should be Base64 decoded to
-     obtain the attachment.
+    The body of the attachment. If `contentEncoding` is `IDENTITY`, the attachment
+    is simply the string. If it's `BASE64`, the string should be Base64 decoded to
+    obtain the attachment.
     """
 
     content_encoding: AttachmentContentEncoding
     """
-    *
-     Whether to interpret `body` "as-is" (IDENTITY) or if it needs to be Base64-decoded (BASE64).
+    Whether to interpret `body` "as-is" (IDENTITY) or if it needs to be Base64-decoded (BASE64).
 
-     Content encoding is *not* determined by the media type, but rather by the type
-     of the object being attached:
+    Content encoding is *not* determined by the media type, but rather by the type
+    of the object being attached:
 
-     - string: IDENTITY
-     - byte array: BASE64
-     - stream: BASE64
+    - string: IDENTITY
+    - byte array: BASE64
+    - stream: BASE64
     """
 
     media_type: str
     """
-    *
-     The media type of the data. This can be any valid
-     [IANA Media Type](https://www.iana.org/assignments/media-types/media-types.xhtml)
-     as well as Cucumber-specific media types such as `text/x.cucumber.gherkin+plain`
-     and `text/x.cucumber.stacktrace+plain`
+    The media type of the data. This can be any valid
+    [IANA Media Type](https://www.iana.org/assignments/media-types/media-types.xhtml)
+    as well as Cucumber-specific media types such as `text/x.cucumber.gherkin+plain`
+    and `text/x.cucumber.stacktrace+plain`
     """
 
-    file_name: Optional[str] = None
-    """
-    *
-     Suggested file name of the attachment. (Provided by the user as an argument to `attach`)
-    """
-
+    file_name: Optional[str] = None  # Suggested file name of the attachment. (Provided by the user as an argument to `attach`)
     source: Optional[Source] = None
     test_case_started_id: Optional[str] = None  # The identifier of the test case attempt if the attachment was created during the execution of a test step
     test_run_hook_started_id: Optional[str] = None  # The identifier of the test run hook execution if the attachment was created during the execution of a test run hook
@@ -68,18 +59,17 @@ class Attachment:
     timestamp: Optional[Timestamp] = None  # When the attachment was created
     url: Optional[str] = None
     """
-    *
-     A URL where the attachment can be retrieved. This field should not be set by Cucumber.
-     It should be set by a program that reads a message stream and does the following for
-     each Attachment message:
+    A URL where the attachment can be retrieved. This field should not be set by Cucumber.
+    It should be set by a program that reads a message stream and does the following for
+    each Attachment message:
 
-     - Writes the body (after base64 decoding if necessary) to a new file.
-     - Sets `body` and `contentEncoding` to `null`
-     - Writes out the new attachment message
+    - Writes the body (after base64 decoding if necessary) to a new file.
+    - Sets `body` and `contentEncoding` to `null`
+    - Writes out the new attachment message
 
-     This will result in a smaller message stream, which can improve performance and
-     reduce bandwidth of message consumers. It also makes it easier to process and download attachments
-     separately from reports.
+    This will result in a smaller message stream, which can improve performance and
+    reduce bandwidth of message consumers. It also makes it easier to process and download attachments
+    separately from reports.
     """
 
 
@@ -88,14 +78,14 @@ class Attachment:
 class Duration:
     """
     The structure is pretty close of the Timestamp one. For clarity, a second type
-     of message is used.
+    of message is used.
     """
     nanos: int
     """
     Non-negative fractions of a second at nanosecond resolution. Negative
-     second values with fractions must still have non-negative nanos values
-     that count forward in time. Must be from 0 to 999,999,999
-     inclusive.
+    second values with fractions must still have non-negative nanos values
+    that count forward in time. Must be from 0 to 999,999,999
+    inclusive.
     """
 
     seconds: int
@@ -103,15 +93,6 @@ class Duration:
 
 @dataclass
 class Envelope:
-    """
-    When removing a field, replace it with reserved, rather than deleting the line.
-     When adding a field, add it to the end and increment the number by one.
-     See https://developers.google.com/protocol-buffers/docs/proto#updating for details
-
-    *
-     All the messages that are passed between different components/processes are Envelope
-     messages.
-    """
     attachment: Optional[Attachment] = None
     gherkin_document: Optional[GherkinDocument] = None
     hook: Optional[Hook] = None
@@ -146,21 +127,19 @@ class Exception:
 @dataclass
 class GherkinDocument:
     """
-    *
-     The [AST](https://en.wikipedia.org/wiki/Abstract_syntax_tree) of a Gherkin document.
-     Cucumber implementations should *not* depend on `GherkinDocument` or any of its
-     children for execution - use [Pickle](#io.cucumber.messages.Pickle) instead.
+    The [AST](https://en.wikipedia.org/wiki/Abstract_syntax_tree) of a Gherkin document.
+    Cucumber implementations should *not* depend on `GherkinDocument` or any of its
+    children for execution - use [Pickle](#io.cucumber.messages.Pickle) instead.
 
-     The only consumers of `GherkinDocument` should only be formatters that produce
-     "rich" output, resembling the original Gherkin document.
+    The only consumers of `GherkinDocument` should only be formatters that produce
+    "rich" output, resembling the original Gherkin document.
     """
     comments: list[Comment]  # All the comments in the Gherkin document
     feature: Optional[Feature] = None
     uri: Optional[str] = None
     """
-    *
-     The [URI](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier)
-     of the source, typically a file path relative to the root directory
+    The [URI](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier)
+    of the source, typically a file path relative to the root directory
     """
 
 
@@ -178,8 +157,7 @@ class Background:
 @dataclass
 class Comment:
     """
-    *
-     A comment in a Gherkin document
+    A comment in a Gherkin document
     """
     location: Location  # The location of the comment
     text: str  # The text of the comment
@@ -225,8 +203,7 @@ class Feature:
 @dataclass
 class FeatureChild:
     """
-    *
-     A child node of a `Feature` node
+    A child node of a `Feature` node
     """
     background: Optional[Background] = None
     rule: Optional[Rule] = None
@@ -247,8 +224,7 @@ class Rule:
 @dataclass
 class RuleChild:
     """
-    *
-     A child node of a `Rule` node
+    A child node of a `Rule` node
     """
     background: Optional[Background] = None
     scenario: Optional[Scenario] = None
@@ -302,8 +278,7 @@ class TableRow:
 @dataclass
 class Tag:
     """
-    *
-     A tag
+    A tag
     """
     id: str  # Unique ID to be able to reference the Tag from PickleTag
     location: Location  # Location of the tag
@@ -322,8 +297,7 @@ class Hook:
 @dataclass
 class Location:
     """
-    *
-     Points to a line and a column in a text file
+    Points to a line and a column in a text file
     """
     line: int
     column: Optional[int] = None
@@ -332,19 +306,13 @@ class Location:
 @dataclass
 class Meta:
     """
-    *
-     This message contains meta information about the environment. Consumers can use
-     this for various purposes.
+    This message contains meta information about the environment. Consumers can use
+    this for various purposes.
     """
     cpu: Product  # 386, arm, amd64 etc
     implementation: Product  # SpecFlow, Cucumber-JVM, Cucumber.js, Cucumber-Ruby, Behat etc.
     os: Product  # Windows, Linux, MacOS etc
-    protocol_version: str
-    """
-    *
-     The [SEMVER](https://semver.org/) version number of the protocol
-    """
-
+    protocol_version: str  # The [SEMVER](https://semver.org/) version number of the protocol
     runtime: Product  # Java, Ruby, Node.js etc
     ci: Optional[Ci] = None
 
@@ -364,7 +332,7 @@ class Ci:
 class Git:
     """
     Information about Git, provided by the Build/CI server as environment
-     variables.
+    variables.
     """
     remote: str
     revision: str
@@ -400,42 +368,32 @@ class ParseError:
 @dataclass
 class Pickle:
     """
-    //// Pickles
+    A `Pickle` represents a template for a `TestCase`. It is typically derived
+    from another format, such as [GherkinDocument](#io.cucumber.messages.GherkinDocument).
+    In the future a `Pickle` may be derived from other formats such as Markdown or
+    Excel files.
 
-    *
-     A `Pickle` represents a template for a `TestCase`. It is typically derived
-     from another format, such as [GherkinDocument](#io.cucumber.messages.GherkinDocument).
-     In the future a `Pickle` may be derived from other formats such as Markdown or
-     Excel files.
+    By making `Pickle` the main data structure Cucumber uses for execution, the
+    implementation of Cucumber itself becomes simpler, as it doesn't have to deal
+    with the complex structure of a [GherkinDocument](#io.cucumber.messages.GherkinDocument).
 
-     By making `Pickle` the main data structure Cucumber uses for execution, the
-     implementation of Cucumber itself becomes simpler, as it doesn't have to deal
-     with the complex structure of a [GherkinDocument](#io.cucumber.messages.GherkinDocument).
-
-     Each `PickleStep` of a `Pickle` is matched with a `StepDefinition` to create a `TestCase`
+    Each `PickleStep` of a `Pickle` is matched with a `StepDefinition` to create a `TestCase`
     """
     ast_node_ids: list[str]
     """
-    *
-     Points to the AST node locations of the pickle. The last one represents the unique
-     id of the pickle. A pickle constructed from `Examples` will have the first
-     id originating from the `Scenario` AST node, and the second from the `TableRow` AST node.
+    Points to the AST node locations of the pickle. The last one represents the unique
+    id of the pickle. A pickle constructed from `Examples` will have the first
+    id originating from the `Scenario` AST node, and the second from the `TableRow` AST node.
     """
 
-    id: str
-    """
-    *
-     A unique id for the pickle
-    """
-
+    id: str  # A unique id for the pickle
     language: str  # The language of the pickle
     name: str  # The name of the pickle
     steps: list[PickleStep]  # One or more steps
     tags: list[PickleTag]
     """
-    *
-     One or more tags. If this pickle is constructed from a Gherkin document,
-     It includes inherited tags from the `Feature` as well.
+    One or more tags. If this pickle is constructed from a Gherkin document,
+    It includes inherited tags from the `Feature` as well.
     """
 
     uri: str  # The uri of the source file
@@ -450,13 +408,12 @@ class PickleDocString:
 @dataclass
 class PickleStep:
     """
-    *
-     An executable step
+    An executable step
     """
     ast_node_ids: list[str]
     """
     References the IDs of the source of the step. For Gherkin, this can be
-     the ID of a Step, and possibly also the ID of a TableRow
+    the ID of a Step, and possibly also the ID of a TableRow
     """
 
     id: str  # A unique ID for the PickleStep
@@ -498,8 +455,7 @@ class PickleTableRow:
 @dataclass
 class PickleTag:
     """
-    *
-     A tag
+    A tag
     """
     ast_node_id: str  # Points to the AST node this was created from
     name: str
@@ -508,23 +464,19 @@ class PickleTag:
 @dataclass
 class Source:
     """
-    //// Source
-
-    *
-     A source file, typically a Gherkin document or Java/Ruby/JavaScript source code
+    A source file, typically a Gherkin document or Java/Ruby/JavaScript source code
     """
     data: str  # The contents of the file
     media_type: SourceMediaType
     """
     The media type of the file. Can be used to specify custom types, such as
-     text/x.cucumber.gherkin+plain
+    text/x.cucumber.gherkin+plain
     """
 
     uri: str
     """
-    *
-     The [URI](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier)
-     of the source, typically a file path relative to the root directory
+    The [URI](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier)
+    of the source, typically a file path relative to the root directory
     """
 
 
@@ -532,9 +484,8 @@ class Source:
 @dataclass
 class SourceReference:
     """
-    *
-     Points to a [Source](#io.cucumber.messages.Source) identified by `uri` and a
-     [Location](#io.cucumber.messages.Location) within that file.
+    Points to a [Source](#io.cucumber.messages.Source) identified by `uri` and a
+    [Location](#io.cucumber.messages.Location) within that file.
     """
     java_method: Optional[JavaMethod] = None
     java_stack_trace_element: Optional[JavaStackTraceElement] = None
@@ -572,10 +523,7 @@ class StepDefinitionPattern:
 @dataclass
 class TestCase:
     """
-    //// TestCases
-
-    *
-     A `TestCase` contains a sequence of `TestStep`s.
+    A `TestCase` contains a sequence of `TestStep`s.
     """
     id: str
     pickle_id: str  # The ID of the `Pickle` this `TestCase` is derived from.
@@ -593,19 +541,17 @@ class Group:
 @dataclass
 class StepMatchArgument:
     """
-    *
-     Represents a single argument extracted from a step match and passed to a step definition.
-     This is used for the following purposes:
-     - Construct an argument to pass to a step definition (possibly through a parameter type transform)
-     - Highlight the matched parameter in rich formatters such as the HTML formatter
+    Represents a single argument extracted from a step match and passed to a step definition.
+    This is used for the following purposes:
+    - Construct an argument to pass to a step definition (possibly through a parameter type transform)
+    - Highlight the matched parameter in rich formatters such as the HTML formatter
 
-     This message closely matches the `Argument` class in the `cucumber-expressions` library.
+    This message closely matches the `Argument` class in the `cucumber-expressions` library.
     """
     group: Group
     """
-    *
-     Represents the outermost capture group of an argument. This message closely matches the
-     `Group` class in the `cucumber-expressions` library.
+    Represents the outermost capture group of an argument. This message closely matches the
+    `Group` class in the `cucumber-expressions` library.
     """
 
     parameter_type_name: Optional[str] = None
@@ -619,9 +565,8 @@ class StepMatchArgumentsList:
 @dataclass
 class TestStep:
     """
-    *
-     A `TestStep` is derived from either a `PickleStep`
-     combined with a `StepDefinition`, or from a `Hook`.
+    A `TestStep` is derived from either a `PickleStep`
+    combined with a `StepDefinition`, or from a `Hook`.
     """
     id: str
     hook_id: Optional[str] = None  # Pointer to the `Hook` (if derived from a Hook)
@@ -629,8 +574,8 @@ class TestStep:
     step_definition_ids: Optional[list[str]] = None
     """
     Pointer to all the matching `StepDefinition`s (if derived from a `PickleStep`)
-     Each element represents a matching step definition. A size of 0 means `UNDEFINED`,
-     and a size of 2+ means `AMBIGUOUS`
+    Each element represents a matching step definition. A size of 0 means `UNDEFINED`,
+    and a size of 2+ means `AMBIGUOUS`
     """
 
     step_match_arguments_lists: Optional[list[StepMatchArgumentsList]] = None  # A list of list of StepMatchArgument (if derived from a `PickleStep`).
@@ -647,16 +592,14 @@ class TestCaseFinished:
 class TestCaseStarted:
     attempt: int
     """
-    *
-     The first attempt should have value 0, and for each retry the value
-     should increase by 1.
+    The first attempt should have value 0, and for each retry the value
+    should increase by 1.
     """
 
     id: str
     """
-    *
-     Because a `TestCase` can be run multiple times (in case of a retry),
-     we use this field to group messages relating to the same attempt.
+    Because a `TestCase` can be run multiple times (in case of a retry),
+    we use this field to group messages relating to the same attempt.
     """
 
     test_case_id: str
@@ -722,16 +665,16 @@ class Timestamp:
     nanos: int
     """
     Non-negative fractions of a second at nanosecond resolution. Negative
-     second values with fractions must still have non-negative nanos values
-     that count forward in time. Must be from 0 to 999,999,999
-     inclusive.
+    second values with fractions must still have non-negative nanos values
+    that count forward in time. Must be from 0 to 999,999,999
+    inclusive.
     """
 
     seconds: int
     """
     Represents seconds of UTC time since Unix epoch
-     1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
-     9999-12-31T23:59:59Z inclusive.
+    1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
+    9999-12-31T23:59:59Z inclusive.
     """
 
 

--- a/ruby/lib/cucumber/messages/attachment.rb
+++ b/ruby/lib/cucumber/messages/attachment.rb
@@ -7,53 +7,48 @@ module Cucumber
     # Represents the Attachment message in Cucumber's {message protocol}[https://github.com/cucumber/messages].
     ##
     #
-    # //// Attachments (parse errors, execution errors, screenshots, links...)
+    # Attachments (parse errors, execution errors, screenshots, links...)
     #
-    # *
-    #  An attachment represents any kind of data associated with a line in a
-    #  [Source](#io.cucumber.messages.Source) file. It can be used for:
+    # An attachment represents any kind of data associated with a line in a
+    # [Source](#io.cucumber.messages.Source) file. It can be used for:
     #
-    #  * Syntax errors during parse time
-    #  * Screenshots captured and attached during execution
-    #  * Logs captured and attached during execution
+    # * Syntax errors during parse time
+    # * Screenshots captured and attached during execution
+    # * Logs captured and attached during execution
     #
-    #  It is not to be used for runtime errors raised/thrown during execution. This
-    #  is captured in `TestResult`.
+    # It is not to be used for runtime errors raised/thrown during execution. This
+    # is captured in `TestResult`.
     ##
     class Attachment < Message
       ##
-      # *
-      #  The body of the attachment. If `contentEncoding` is `IDENTITY`, the attachment
-      #  is simply the string. If it's `BASE64`, the string should be Base64 decoded to
-      #  obtain the attachment.
+      # The body of the attachment. If `contentEncoding` is `IDENTITY`, the attachment
+      # is simply the string. If it's `BASE64`, the string should be Base64 decoded to
+      # obtain the attachment.
       ##
       attr_reader :body
 
       ##
-      # *
-      #  Whether to interpret `body` "as-is" (IDENTITY) or if it needs to be Base64-decoded (BASE64).
+      # Whether to interpret `body` "as-is" (IDENTITY) or if it needs to be Base64-decoded (BASE64).
       #
-      #  Content encoding is *not* determined by the media type, but rather by the type
-      #  of the object being attached:
+      # Content encoding is *not* determined by the media type, but rather by the type
+      # of the object being attached:
       #
-      #  - string: IDENTITY
-      #  - byte array: BASE64
-      #  - stream: BASE64
+      # - string: IDENTITY
+      # - byte array: BASE64
+      # - stream: BASE64
       ##
       attr_reader :content_encoding
 
       ##
-      # *
-      #  Suggested file name of the attachment. (Provided by the user as an argument to `attach`)
+      # Suggested file name of the attachment. (Provided by the user as an argument to `attach`)
       ##
       attr_reader :file_name
 
       ##
-      # *
-      #  The media type of the data. This can be any valid
-      #  [IANA Media Type](https://www.iana.org/assignments/media-types/media-types.xhtml)
-      #  as well as Cucumber-specific media types such as `text/x.cucumber.gherkin+plain`
-      #  and `text/x.cucumber.stacktrace+plain`
+      # The media type of the data. This can be any valid
+      # [IANA Media Type](https://www.iana.org/assignments/media-types/media-types.xhtml)
+      # as well as Cucumber-specific media types such as `text/x.cucumber.gherkin+plain`
+      # and `text/x.cucumber.stacktrace+plain`
       ##
       attr_reader :media_type
 
@@ -70,18 +65,17 @@ module Cucumber
       attr_reader :test_step_id
 
       ##
-      # *
-      #  A URL where the attachment can be retrieved. This field should not be set by Cucumber.
-      #  It should be set by a program that reads a message stream and does the following for
-      #  each Attachment message:
+      # A URL where the attachment can be retrieved. This field should not be set by Cucumber.
+      # It should be set by a program that reads a message stream and does the following for
+      # each Attachment message:
       #
-      #  - Writes the body (after base64 decoding if necessary) to a new file.
-      #  - Sets `body` and `contentEncoding` to `null`
-      #  - Writes out the new attachment message
+      # - Writes the body (after base64 decoding if necessary) to a new file.
+      # - Sets `body` and `contentEncoding` to `null`
+      # - Writes out the new attachment message
       #
-      #  This will result in a smaller message stream, which can improve performance and
-      #  reduce bandwidth of message consumers. It also makes it easier to process and download attachments
-      #  separately from reports.
+      # This will result in a smaller message stream, which can improve performance and
+      # reduce bandwidth of message consumers. It also makes it easier to process and download attachments
+      # separately from reports.
       ##
       attr_reader :url
 

--- a/ruby/lib/cucumber/messages/comment.rb
+++ b/ruby/lib/cucumber/messages/comment.rb
@@ -7,8 +7,7 @@ module Cucumber
     # Represents the Comment message in Cucumber's {message protocol}[https://github.com/cucumber/messages].
     ##
     #
-    # *
-    #  A comment in a Gherkin document
+    # A comment in a Gherkin document
     ##
     class Comment < Message
       ##

--- a/ruby/lib/cucumber/messages/duration.rb
+++ b/ruby/lib/cucumber/messages/duration.rb
@@ -8,16 +8,16 @@ module Cucumber
     ##
     #
     # The structure is pretty close of the Timestamp one. For clarity, a second type
-    #  of message is used.
+    # of message is used.
     ##
     class Duration < Message
       attr_reader :seconds
 
       ##
       # Non-negative fractions of a second at nanosecond resolution. Negative
-      #  second values with fractions must still have non-negative nanos values
-      #  that count forward in time. Must be from 0 to 999,999,999
-      #  inclusive.
+      # second values with fractions must still have non-negative nanos values
+      # that count forward in time. Must be from 0 to 999,999,999
+      # inclusive.
       ##
       attr_reader :nanos
 

--- a/ruby/lib/cucumber/messages/envelope.rb
+++ b/ruby/lib/cucumber/messages/envelope.rb
@@ -6,14 +6,6 @@ module Cucumber
     ##
     # Represents the Envelope message in Cucumber's {message protocol}[https://github.com/cucumber/messages].
     ##
-    #
-    # When removing a field, replace it with reserved, rather than deleting the line.
-    #  When adding a field, add it to the end and increment the number by one.
-    #  See https://developers.google.com/protocol-buffers/docs/proto#updating for details
-    #
-    # *
-    #  All the messages that are passed between different components/processes are Envelope
-    #  messages.
     ##
     class Envelope < Message
       attr_reader :attachment

--- a/ruby/lib/cucumber/messages/feature_child.rb
+++ b/ruby/lib/cucumber/messages/feature_child.rb
@@ -7,8 +7,7 @@ module Cucumber
     # Represents the FeatureChild message in Cucumber's {message protocol}[https://github.com/cucumber/messages].
     ##
     #
-    # *
-    #  A child node of a `Feature` node
+    # A child node of a `Feature` node
     ##
     class FeatureChild < Message
       attr_reader :rule

--- a/ruby/lib/cucumber/messages/gherkin_document.rb
+++ b/ruby/lib/cucumber/messages/gherkin_document.rb
@@ -7,19 +7,17 @@ module Cucumber
     # Represents the GherkinDocument message in Cucumber's {message protocol}[https://github.com/cucumber/messages].
     ##
     #
-    # *
-    #  The [AST](https://en.wikipedia.org/wiki/Abstract_syntax_tree) of a Gherkin document.
-    #  Cucumber implementations should *not* depend on `GherkinDocument` or any of its
-    #  children for execution - use [Pickle](#io.cucumber.messages.Pickle) instead.
+    # The [AST](https://en.wikipedia.org/wiki/Abstract_syntax_tree) of a Gherkin document.
+    # Cucumber implementations should *not* depend on `GherkinDocument` or any of its
+    # children for execution - use [Pickle](#io.cucumber.messages.Pickle) instead.
     #
-    #  The only consumers of `GherkinDocument` should only be formatters that produce
-    #  "rich" output, resembling the original Gherkin document.
+    # The only consumers of `GherkinDocument` should only be formatters that produce
+    # "rich" output, resembling the original Gherkin document.
     ##
     class GherkinDocument < Message
       ##
-      # *
-      #  The [URI](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier)
-      #  of the source, typically a file path relative to the root directory
+      # The [URI](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier)
+      # of the source, typically a file path relative to the root directory
       ##
       attr_reader :uri
 

--- a/ruby/lib/cucumber/messages/git.rb
+++ b/ruby/lib/cucumber/messages/git.rb
@@ -8,7 +8,7 @@ module Cucumber
     ##
     #
     # Information about Git, provided by the Build/CI server as environment
-    #  variables.
+    # variables.
     ##
     class Git < Message
       attr_reader :remote

--- a/ruby/lib/cucumber/messages/location.rb
+++ b/ruby/lib/cucumber/messages/location.rb
@@ -7,8 +7,7 @@ module Cucumber
     # Represents the Location message in Cucumber's {message protocol}[https://github.com/cucumber/messages].
     ##
     #
-    # *
-    #  Points to a line and a column in a text file
+    # Points to a line and a column in a text file
     ##
     class Location < Message
       attr_reader :line

--- a/ruby/lib/cucumber/messages/meta.rb
+++ b/ruby/lib/cucumber/messages/meta.rb
@@ -7,14 +7,12 @@ module Cucumber
     # Represents the Meta message in Cucumber's {message protocol}[https://github.com/cucumber/messages].
     ##
     #
-    # *
-    #  This message contains meta information about the environment. Consumers can use
-    #  this for various purposes.
+    # This message contains meta information about the environment. Consumers can use
+    # this for various purposes.
     ##
     class Meta < Message
       ##
-      # *
-      #  The [SEMVER](https://semver.org/) version number of the protocol
+      # The [SEMVER](https://semver.org/) version number of the protocol
       ##
       attr_reader :protocol_version
 

--- a/ruby/lib/cucumber/messages/pickle.rb
+++ b/ruby/lib/cucumber/messages/pickle.rb
@@ -7,24 +7,20 @@ module Cucumber
     # Represents the Pickle message in Cucumber's {message protocol}[https://github.com/cucumber/messages].
     ##
     #
-    # //// Pickles
+    # A `Pickle` represents a template for a `TestCase`. It is typically derived
+    # from another format, such as [GherkinDocument](#io.cucumber.messages.GherkinDocument).
+    # In the future a `Pickle` may be derived from other formats such as Markdown or
+    # Excel files.
     #
-    # *
-    #  A `Pickle` represents a template for a `TestCase`. It is typically derived
-    #  from another format, such as [GherkinDocument](#io.cucumber.messages.GherkinDocument).
-    #  In the future a `Pickle` may be derived from other formats such as Markdown or
-    #  Excel files.
+    # By making `Pickle` the main data structure Cucumber uses for execution, the
+    # implementation of Cucumber itself becomes simpler, as it doesn't have to deal
+    # with the complex structure of a [GherkinDocument](#io.cucumber.messages.GherkinDocument).
     #
-    #  By making `Pickle` the main data structure Cucumber uses for execution, the
-    #  implementation of Cucumber itself becomes simpler, as it doesn't have to deal
-    #  with the complex structure of a [GherkinDocument](#io.cucumber.messages.GherkinDocument).
-    #
-    #  Each `PickleStep` of a `Pickle` is matched with a `StepDefinition` to create a `TestCase`
+    # Each `PickleStep` of a `Pickle` is matched with a `StepDefinition` to create a `TestCase`
     ##
     class Pickle < Message
       ##
-      # *
-      #  A unique id for the pickle
+      # A unique id for the pickle
       ##
       attr_reader :id
 
@@ -49,17 +45,15 @@ module Cucumber
       attr_reader :steps
 
       ##
-      # *
-      #  One or more tags. If this pickle is constructed from a Gherkin document,
-      #  It includes inherited tags from the `Feature` as well.
+      # One or more tags. If this pickle is constructed from a Gherkin document,
+      # It includes inherited tags from the `Feature` as well.
       ##
       attr_reader :tags
 
       ##
-      # *
-      #  Points to the AST node locations of the pickle. The last one represents the unique
-      #  id of the pickle. A pickle constructed from `Examples` will have the first
-      #  id originating from the `Scenario` AST node, and the second from the `TableRow` AST node.
+      # Points to the AST node locations of the pickle. The last one represents the unique
+      # id of the pickle. A pickle constructed from `Examples` will have the first
+      # id originating from the `Scenario` AST node, and the second from the `TableRow` AST node.
       ##
       attr_reader :ast_node_ids
 

--- a/ruby/lib/cucumber/messages/pickle_step.rb
+++ b/ruby/lib/cucumber/messages/pickle_step.rb
@@ -7,15 +7,14 @@ module Cucumber
     # Represents the PickleStep message in Cucumber's {message protocol}[https://github.com/cucumber/messages].
     ##
     #
-    # *
-    #  An executable step
+    # An executable step
     ##
     class PickleStep < Message
       attr_reader :argument
 
       ##
       # References the IDs of the source of the step. For Gherkin, this can be
-      #  the ID of a Step, and possibly also the ID of a TableRow
+      # the ID of a Step, and possibly also the ID of a TableRow
       ##
       attr_reader :ast_node_ids
 

--- a/ruby/lib/cucumber/messages/pickle_tag.rb
+++ b/ruby/lib/cucumber/messages/pickle_tag.rb
@@ -7,8 +7,7 @@ module Cucumber
     # Represents the PickleTag message in Cucumber's {message protocol}[https://github.com/cucumber/messages].
     ##
     #
-    # *
-    #  A tag
+    # A tag
     ##
     class PickleTag < Message
       attr_reader :name

--- a/ruby/lib/cucumber/messages/rule_child.rb
+++ b/ruby/lib/cucumber/messages/rule_child.rb
@@ -7,8 +7,7 @@ module Cucumber
     # Represents the RuleChild message in Cucumber's {message protocol}[https://github.com/cucumber/messages].
     ##
     #
-    # *
-    #  A child node of a `Rule` node
+    # A child node of a `Rule` node
     ##
     class RuleChild < Message
       attr_reader :background

--- a/ruby/lib/cucumber/messages/source.rb
+++ b/ruby/lib/cucumber/messages/source.rb
@@ -7,16 +7,12 @@ module Cucumber
     # Represents the Source message in Cucumber's {message protocol}[https://github.com/cucumber/messages].
     ##
     #
-    # //// Source
-    #
-    # *
-    #  A source file, typically a Gherkin document or Java/Ruby/JavaScript source code
+    # A source file, typically a Gherkin document or Java/Ruby/JavaScript source code
     ##
     class Source < Message
       ##
-      # *
-      #  The [URI](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier)
-      #  of the source, typically a file path relative to the root directory
+      # The [URI](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier)
+      # of the source, typically a file path relative to the root directory
       ##
       attr_reader :uri
 
@@ -27,7 +23,7 @@ module Cucumber
 
       ##
       # The media type of the file. Can be used to specify custom types, such as
-      #  text/x.cucumber.gherkin+plain
+      # text/x.cucumber.gherkin+plain
       ##
       attr_reader :media_type
 

--- a/ruby/lib/cucumber/messages/source_reference.rb
+++ b/ruby/lib/cucumber/messages/source_reference.rb
@@ -7,9 +7,8 @@ module Cucumber
     # Represents the SourceReference message in Cucumber's {message protocol}[https://github.com/cucumber/messages].
     ##
     #
-    # *
-    #  Points to a [Source](#io.cucumber.messages.Source) identified by `uri` and a
-    #  [Location](#io.cucumber.messages.Location) within that file.
+    # Points to a [Source](#io.cucumber.messages.Source) identified by `uri` and a
+    # [Location](#io.cucumber.messages.Location) within that file.
     ##
     class SourceReference < Message
       attr_reader :uri

--- a/ruby/lib/cucumber/messages/step_match_argument.rb
+++ b/ruby/lib/cucumber/messages/step_match_argument.rb
@@ -7,19 +7,17 @@ module Cucumber
     # Represents the StepMatchArgument message in Cucumber's {message protocol}[https://github.com/cucumber/messages].
     ##
     #
-    # *
-    #  Represents a single argument extracted from a step match and passed to a step definition.
-    #  This is used for the following purposes:
-    #  - Construct an argument to pass to a step definition (possibly through a parameter type transform)
-    #  - Highlight the matched parameter in rich formatters such as the HTML formatter
+    # Represents a single argument extracted from a step match and passed to a step definition.
+    # This is used for the following purposes:
+    # - Construct an argument to pass to a step definition (possibly through a parameter type transform)
+    # - Highlight the matched parameter in rich formatters such as the HTML formatter
     #
-    #  This message closely matches the `Argument` class in the `cucumber-expressions` library.
+    # This message closely matches the `Argument` class in the `cucumber-expressions` library.
     ##
     class StepMatchArgument < Message
       ##
-      # *
-      #  Represents the outermost capture group of an argument. This message closely matches the
-      #  `Group` class in the `cucumber-expressions` library.
+      # Represents the outermost capture group of an argument. This message closely matches the
+      # `Group` class in the `cucumber-expressions` library.
       ##
       attr_reader :group
 

--- a/ruby/lib/cucumber/messages/tag.rb
+++ b/ruby/lib/cucumber/messages/tag.rb
@@ -7,8 +7,7 @@ module Cucumber
     # Represents the Tag message in Cucumber's {message protocol}[https://github.com/cucumber/messages].
     ##
     #
-    # *
-    #  A tag
+    # A tag
     ##
     class Tag < Message
       ##

--- a/ruby/lib/cucumber/messages/test_case.rb
+++ b/ruby/lib/cucumber/messages/test_case.rb
@@ -7,10 +7,7 @@ module Cucumber
     # Represents the TestCase message in Cucumber's {message protocol}[https://github.com/cucumber/messages].
     ##
     #
-    # //// TestCases
-    #
-    # *
-    #  A `TestCase` contains a sequence of `TestStep`s.
+    # A `TestCase` contains a sequence of `TestStep`s.
     ##
     class TestCase < Message
       attr_reader :id

--- a/ruby/lib/cucumber/messages/test_case_started.rb
+++ b/ruby/lib/cucumber/messages/test_case_started.rb
@@ -9,16 +9,14 @@ module Cucumber
     ##
     class TestCaseStarted < Message
       ##
-      # *
-      #  The first attempt should have value 0, and for each retry the value
-      #  should increase by 1.
+      # The first attempt should have value 0, and for each retry the value
+      # should increase by 1.
       ##
       attr_reader :attempt
 
       ##
-      # *
-      #  Because a `TestCase` can be run multiple times (in case of a retry),
-      #  we use this field to group messages relating to the same attempt.
+      # Because a `TestCase` can be run multiple times (in case of a retry),
+      # we use this field to group messages relating to the same attempt.
       ##
       attr_reader :id
 

--- a/ruby/lib/cucumber/messages/test_step.rb
+++ b/ruby/lib/cucumber/messages/test_step.rb
@@ -7,9 +7,8 @@ module Cucumber
     # Represents the TestStep message in Cucumber's {message protocol}[https://github.com/cucumber/messages].
     ##
     #
-    # *
-    #  A `TestStep` is derived from either a `PickleStep`
-    #  combined with a `StepDefinition`, or from a `Hook`.
+    # A `TestStep` is derived from either a `PickleStep`
+    # combined with a `StepDefinition`, or from a `Hook`.
     ##
     class TestStep < Message
       ##
@@ -26,8 +25,8 @@ module Cucumber
 
       ##
       # Pointer to all the matching `StepDefinition`s (if derived from a `PickleStep`)
-      #  Each element represents a matching step definition. A size of 0 means `UNDEFINED`,
-      #  and a size of 2+ means `AMBIGUOUS`
+      # Each element represents a matching step definition. A size of 0 means `UNDEFINED`,
+      # and a size of 2+ means `AMBIGUOUS`
       ##
       attr_reader :step_definition_ids
 

--- a/ruby/lib/cucumber/messages/timestamp.rb
+++ b/ruby/lib/cucumber/messages/timestamp.rb
@@ -10,16 +10,16 @@ module Cucumber
     class Timestamp < Message
       ##
       # Represents seconds of UTC time since Unix epoch
-      #  1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
-      #  9999-12-31T23:59:59Z inclusive.
+      # 1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
+      # 9999-12-31T23:59:59Z inclusive.
       ##
       attr_reader :seconds
 
       ##
       # Non-negative fractions of a second at nanosecond resolution. Negative
-      #  second values with fractions must still have non-negative nanos values
-      #  that count forward in time. Must be from 0 to 999,999,999
-      #  inclusive.
+      # second values with fractions must still have non-negative nanos values
+      # that count forward in time. Must be from 0 to 999,999,999
+      # inclusive.
       ##
       attr_reader :nanos
 


### PR DESCRIPTION
### ⚡️ What's your motivation? 

The json schema contained several spurious space, astrix and other bit of text. Removing these makes the documentation much easier to read.

There are other mistakes still present but they're not so easy to spot automatically.

### 🏷️ What kind of change is this?

- :book: Documentation (improvements without changing code)

### 📋 Checklist:


- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.
