### PR TITLE
Update documentation for `TestStepResult.message`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Update documentation for `TestStepResult.message` ([#315](https://github.com/cucumber/messages/pull/315))
 
 ## [28.1.0] - 2025-07-21
 ### Added

--- a/dotnet/Cucumber.Messages/generated/TestStepResult.cs
+++ b/dotnet/Cucumber.Messages/generated/TestStepResult.cs
@@ -18,7 +18,7 @@ public sealed class TestStepResult
 {
     public Duration Duration { get; private set; }
     /**
-     * An arbitrary bit of information that explains this result. This can be a stack trace of anything else.
+     * An arbitrary bit of information that explains this result. If there was an exception, this should include a stringified representation of it including type, message and stack trace (the exact format will vary by platform).
      */
     public string Message { get; private set; }
     public TestStepResultStatus Status { get; private set; }

--- a/java/src/generated/java/io/cucumber/messages/types/TestStepResult.java
+++ b/java/src/generated/java/io/cucumber/messages/types/TestStepResult.java
@@ -35,7 +35,7 @@ public final class TestStepResult {
     }
 
     /**
-      * An arbitrary bit of information that explains this result. This can be a stack trace of anything else.
+      * An arbitrary bit of information that explains this result. If there was an exception, this should include a stringified representation of it including type, message and stack trace (the exact format will vary by platform).
      */
     public Optional<String> getMessage() {
         return Optional.ofNullable(message);

--- a/jsonschema/src/TestStepResult.json
+++ b/jsonschema/src/TestStepResult.json
@@ -12,7 +12,7 @@
     },
     "message": {
       "type": "string",
-      "description": "An arbitrary bit of information that explains this result. This can be a stack trace of anything else."
+      "description": "An arbitrary bit of information that explains this result. If there was an exception, this should include a stringified representation of it including type, message and stack trace (the exact format will vary by platform)."
     },
     "status": {
       "enum": [

--- a/perl/lib/Cucumber/Messages.pm
+++ b/perl/lib/Cucumber/Messages.pm
@@ -4665,7 +4665,7 @@ has duration =>
 
 =head4 message
 
-An arbitrary bit of information that explains this result. This can be a stack trace of anything else.
+An arbitrary bit of information that explains this result. If there was an exception, this should include a stringified representation of it including type, message and stack trace (the exact format will vary by platform).
 =cut
 
 has message =>

--- a/php/src-generated/TestStepResult.php
+++ b/php/src-generated/TestStepResult.php
@@ -28,7 +28,7 @@ final class TestStepResult implements JsonSerializable
         public readonly Duration $duration = new Duration(),
 
         /**
-         * An arbitrary bit of information that explains this result. This can be a stack trace of anything else.
+         * An arbitrary bit of information that explains this result. If there was an exception, this should include a stringified representation of it including type, message and stack trace (the exact format will vary by platform).
          */
         public readonly ?string $message = null,
         public readonly TestStepResult\Status $status = TestStepResult\Status::UNKNOWN,

--- a/python/src/cucumber_messages/_messages.py
+++ b/python/src/cucumber_messages/_messages.py
@@ -650,7 +650,7 @@ class TestStepResult:
     duration: Duration
     status: TestStepResultStatus
     exception: Optional[Exception] = None  # Exception thrown while executing this step, if any.
-    message: Optional[str] = None  # An arbitrary bit of information that explains this result. This can be a stack trace of anything else.
+    message: Optional[str] = None  # An arbitrary bit of information that explains this result. If there was an exception, this should include a stringified representation of it including type, message and stack trace (the exact format will vary by platform).
 
 
 @dataclass

--- a/ruby/lib/cucumber/messages/test_step_result.rb
+++ b/ruby/lib/cucumber/messages/test_step_result.rb
@@ -11,7 +11,7 @@ module Cucumber
       attr_reader :duration
 
       ##
-      # An arbitrary bit of information that explains this result. This can be a stack trace of anything else.
+      # An arbitrary bit of information that explains this result. If there was an exception, this should include a stringified representation of it including type, message and stack trace (the exact format will vary by platform).
       ##
       attr_reader :message
 


### PR DESCRIPTION
### 🤔 What's changed?

Expand on the documentation for `TestStepResult.message` to be clear that it should include the exception if there was one.

### ⚡️ What's your motivation? 

See https://github.com/cucumber/pretty-formatter/issues/12

### 🏷️ What kind of change is this?

- :book: Documentation (improvements without changing code)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
