### PR TITLE
Include description in documentation

### DIFF
--- a/codegen/templates/markdown.md.erb
+++ b/codegen/templates/markdown.md.erb
@@ -6,14 +6,21 @@ will only have one of its fields set, which indicates the payload of the message
 <% @schemas.each do |key, schema| -%>
 ## <%= class_name(key) %>
 
-| Field | Type | Required    | Description |
-| ----- | ---- | ----------- | ----------- |
-<% schema['properties'].each do |property_name, property| -%>
+<%= schema['description'] %>
+<%- schema['properties'].each do |property_name, property| -%>
   <%-
   type_name = type_for(class_name(key), property_name, property)
   required = (schema['required'] || []).index(property_name)
+  description = ( property['description'] || '')
   -%>
-  <%- %>| `<%= property_name %>` | <%= type_name %> | <%= required ? 'yes' : 'no' %> | |
-<% end -%>
 
-<% end -%>
+### .<%= property_name %> 
+
+* Type: <%= type_name %> 
+* Required: <%= required ? 'yes' : 'no' %> 
+
+<%= description -%>
+
+<%- end -%>
+
+<%- end -%>

--- a/jsonschema/messages.md
+++ b/jsonschema/messages.md
@@ -5,512 +5,1877 @@ will only have one of its fields set, which indicates the payload of the message
 
 ## Attachment
 
-| Field | Type | Required    | Description |
-| ----- | ---- | ----------- | ----------- |
-| `body` | string | yes | |
-| `contentEncoding` | [AttachmentContentEncoding](#attachmentcontentencoding) | yes | |
-| `fileName` | string | no | |
-| `mediaType` | string | yes | |
-| `source` | [Source](#source) | no | |
-| `testCaseStartedId` | string | no | |
-| `testStepId` | string | no | |
-| `url` | string | no | |
-| `testRunStartedId` | string | no | |
-| `testRunHookStartedId` | string | no | |
-| `timestamp` | [Timestamp](#timestamp) | no | |
+Attachments (parse errors, execution errors, screenshots, links...)
+
+An attachment represents any kind of data associated with a line in a
+[Source](#io.cucumber.messages.Source) file. It can be used for:
+
+* Syntax errors during parse time
+* Screenshots captured and attached during execution
+* Logs captured and attached during execution
+
+It is not to be used for runtime errors raised/thrown during execution. This
+is captured in `TestResult`.
+
+### .body 
+
+* Type: string 
+* Required: yes 
+
+The body of the attachment. If `contentEncoding` is `IDENTITY`, the attachment
+is simply the string. If it's `BASE64`, the string should be Base64 decoded to
+obtain the attachment.
+
+### .contentEncoding 
+
+* Type: [AttachmentContentEncoding](#attachmentcontentencoding) 
+* Required: yes 
+
+Whether to interpret `body` "as-is" (IDENTITY) or if it needs to be Base64-decoded (BASE64).
+
+Content encoding is *not* determined by the media type, but rather by the type
+of the object being attached:
+
+- string: IDENTITY
+- byte array: BASE64
+- stream: BASE64
+
+### .fileName 
+
+* Type: string 
+* Required: no 
+
+Suggested file name of the attachment. (Provided by the user as an argument to `attach`)
+
+### .mediaType 
+
+* Type: string 
+* Required: yes 
+
+The media type of the data. This can be any valid
+[IANA Media Type](https://www.iana.org/assignments/media-types/media-types.xhtml)
+as well as Cucumber-specific media types such as `text/x.cucumber.gherkin+plain`
+and `text/x.cucumber.stacktrace+plain`
+
+### .source 
+
+* Type: [Source](#source) 
+* Required: no 
+
+
+
+### .testCaseStartedId 
+
+* Type: string 
+* Required: no 
+
+The identifier of the test case attempt if the attachment was created during the execution of a test step
+
+### .testStepId 
+
+* Type: string 
+* Required: no 
+
+The identifier of the test step if the attachment was created during the execution of a test step
+
+### .url 
+
+* Type: string 
+* Required: no 
+
+A URL where the attachment can be retrieved. This field should not be set by Cucumber.
+It should be set by a program that reads a message stream and does the following for
+each Attachment message:
+
+- Writes the body (after base64 decoding if necessary) to a new file.
+- Sets `body` and `contentEncoding` to `null`
+- Writes out the new attachment message
+
+This will result in a smaller message stream, which can improve performance and
+reduce bandwidth of message consumers. It also makes it easier to process and download attachments
+separately from reports.
+
+### .testRunStartedId 
+
+* Type: string 
+* Required: no 
+
+Not used; implementers should instead populate `testRunHookStartedId` if an attachment was created during the execution of a test run hook
+
+### .testRunHookStartedId 
+
+* Type: string 
+* Required: no 
+
+The identifier of the test run hook execution if the attachment was created during the execution of a test run hook
+
+### .timestamp 
+
+* Type: [Timestamp](#timestamp) 
+* Required: no 
+
+When the attachment was created
 
 ## Duration
 
-| Field | Type | Required    | Description |
-| ----- | ---- | ----------- | ----------- |
-| `seconds` | integer | yes | |
-| `nanos` | integer | yes | |
+The structure is pretty close of the Timestamp one. For clarity, a second type
+of message is used.
+
+### .seconds 
+
+* Type: integer 
+* Required: yes 
+
+
+
+### .nanos 
+
+* Type: integer 
+* Required: yes 
+
+Non-negative fractions of a second at nanosecond resolution. Negative
+second values with fractions must still have non-negative nanos values
+that count forward in time. Must be from 0 to 999,999,999
+inclusive.
 
 ## Envelope
 
-| Field | Type | Required    | Description |
-| ----- | ---- | ----------- | ----------- |
-| `attachment` | [Attachment](#attachment) | no | |
-| `gherkinDocument` | [GherkinDocument](#gherkindocument) | no | |
-| `hook` | [Hook](#hook) | no | |
-| `meta` | [Meta](#meta) | no | |
-| `parameterType` | [ParameterType](#parametertype) | no | |
-| `parseError` | [ParseError](#parseerror) | no | |
-| `pickle` | [Pickle](#pickle) | no | |
-| `source` | [Source](#source) | no | |
-| `stepDefinition` | [StepDefinition](#stepdefinition) | no | |
-| `testCase` | [TestCase](#testcase) | no | |
-| `testCaseFinished` | [TestCaseFinished](#testcasefinished) | no | |
-| `testCaseStarted` | [TestCaseStarted](#testcasestarted) | no | |
-| `testRunFinished` | [TestRunFinished](#testrunfinished) | no | |
-| `testRunStarted` | [TestRunStarted](#testrunstarted) | no | |
-| `testStepFinished` | [TestStepFinished](#teststepfinished) | no | |
-| `testStepStarted` | [TestStepStarted](#teststepstarted) | no | |
-| `testRunHookStarted` | [TestRunHookStarted](#testrunhookstarted) | no | |
-| `testRunHookFinished` | [TestRunHookFinished](#testrunhookfinished) | no | |
-| `undefinedParameterType` | [UndefinedParameterType](#undefinedparametertype) | no | |
+
+
+### .attachment 
+
+* Type: [Attachment](#attachment) 
+* Required: no 
+
+
+
+### .gherkinDocument 
+
+* Type: [GherkinDocument](#gherkindocument) 
+* Required: no 
+
+
+
+### .hook 
+
+* Type: [Hook](#hook) 
+* Required: no 
+
+
+
+### .meta 
+
+* Type: [Meta](#meta) 
+* Required: no 
+
+
+
+### .parameterType 
+
+* Type: [ParameterType](#parametertype) 
+* Required: no 
+
+
+
+### .parseError 
+
+* Type: [ParseError](#parseerror) 
+* Required: no 
+
+
+
+### .pickle 
+
+* Type: [Pickle](#pickle) 
+* Required: no 
+
+
+
+### .source 
+
+* Type: [Source](#source) 
+* Required: no 
+
+
+
+### .stepDefinition 
+
+* Type: [StepDefinition](#stepdefinition) 
+* Required: no 
+
+
+
+### .testCase 
+
+* Type: [TestCase](#testcase) 
+* Required: no 
+
+
+
+### .testCaseFinished 
+
+* Type: [TestCaseFinished](#testcasefinished) 
+* Required: no 
+
+
+
+### .testCaseStarted 
+
+* Type: [TestCaseStarted](#testcasestarted) 
+* Required: no 
+
+
+
+### .testRunFinished 
+
+* Type: [TestRunFinished](#testrunfinished) 
+* Required: no 
+
+
+
+### .testRunStarted 
+
+* Type: [TestRunStarted](#testrunstarted) 
+* Required: no 
+
+
+
+### .testStepFinished 
+
+* Type: [TestStepFinished](#teststepfinished) 
+* Required: no 
+
+
+
+### .testStepStarted 
+
+* Type: [TestStepStarted](#teststepstarted) 
+* Required: no 
+
+
+
+### .testRunHookStarted 
+
+* Type: [TestRunHookStarted](#testrunhookstarted) 
+* Required: no 
+
+
+
+### .testRunHookFinished 
+
+* Type: [TestRunHookFinished](#testrunhookfinished) 
+* Required: no 
+
+
+
+### .undefinedParameterType 
+
+* Type: [UndefinedParameterType](#undefinedparametertype) 
+* Required: no 
+
+
 
 ## Exception
 
-| Field | Type | Required    | Description |
-| ----- | ---- | ----------- | ----------- |
-| `type` | string | yes | |
-| `message` | string | no | |
-| `stackTrace` | string | no | |
+A simplified representation of an exception
+
+### .type 
+
+* Type: string 
+* Required: yes 
+
+The type of the exception that caused this result. E.g. "Error" or "org.opentest4j.AssertionFailedError"
+
+### .message 
+
+* Type: string 
+* Required: no 
+
+The message of exception that caused this result. E.g. expected: "a" but was: "b"
+
+### .stackTrace 
+
+* Type: string 
+* Required: no 
+
+The stringified stack trace of the exception that caused this result
 
 ## GherkinDocument
 
-| Field | Type | Required    | Description |
-| ----- | ---- | ----------- | ----------- |
-| `uri` | string | no | |
-| `feature` | [Feature](#feature) | no | |
-| `comments` | [Comment](#comment)[] | yes | |
+The [AST](https://en.wikipedia.org/wiki/Abstract_syntax_tree) of a Gherkin document.
+Cucumber implementations should *not* depend on `GherkinDocument` or any of its
+children for execution - use [Pickle](#io.cucumber.messages.Pickle) instead.
+
+The only consumers of `GherkinDocument` should only be formatters that produce
+"rich" output, resembling the original Gherkin document.
+
+### .uri 
+
+* Type: string 
+* Required: no 
+
+The [URI](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier)
+of the source, typically a file path relative to the root directory
+
+### .feature 
+
+* Type: [Feature](#feature) 
+* Required: no 
+
+
+
+### .comments 
+
+* Type: [Comment](#comment)[] 
+* Required: yes 
+
+All the comments in the Gherkin document
 
 ## Background
 
-| Field | Type | Required    | Description |
-| ----- | ---- | ----------- | ----------- |
-| `location` | [Location](#location) | yes | |
-| `keyword` | string | yes | |
-| `name` | string | yes | |
-| `description` | string | yes | |
-| `steps` | [Step](#step)[] | yes | |
-| `id` | string | yes | |
+
+
+### .location 
+
+* Type: [Location](#location) 
+* Required: yes 
+
+The location of the `Background` keyword
+
+### .keyword 
+
+* Type: string 
+* Required: yes 
+
+
+
+### .name 
+
+* Type: string 
+* Required: yes 
+
+
+
+### .description 
+
+* Type: string 
+* Required: yes 
+
+
+
+### .steps 
+
+* Type: [Step](#step)[] 
+* Required: yes 
+
+
+
+### .id 
+
+* Type: string 
+* Required: yes 
+
+
 
 ## Comment
 
-| Field | Type | Required    | Description |
-| ----- | ---- | ----------- | ----------- |
-| `location` | [Location](#location) | yes | |
-| `text` | string | yes | |
+A comment in a Gherkin document
+
+### .location 
+
+* Type: [Location](#location) 
+* Required: yes 
+
+The location of the comment
+
+### .text 
+
+* Type: string 
+* Required: yes 
+
+The text of the comment
 
 ## DataTable
 
-| Field | Type | Required    | Description |
-| ----- | ---- | ----------- | ----------- |
-| `location` | [Location](#location) | yes | |
-| `rows` | [TableRow](#tablerow)[] | yes | |
+
+
+### .location 
+
+* Type: [Location](#location) 
+* Required: yes 
+
+
+
+### .rows 
+
+* Type: [TableRow](#tablerow)[] 
+* Required: yes 
+
+
 
 ## DocString
 
-| Field | Type | Required    | Description |
-| ----- | ---- | ----------- | ----------- |
-| `location` | [Location](#location) | yes | |
-| `mediaType` | string | no | |
-| `content` | string | yes | |
-| `delimiter` | string | yes | |
+
+
+### .location 
+
+* Type: [Location](#location) 
+* Required: yes 
+
+
+
+### .mediaType 
+
+* Type: string 
+* Required: no 
+
+
+
+### .content 
+
+* Type: string 
+* Required: yes 
+
+
+
+### .delimiter 
+
+* Type: string 
+* Required: yes 
+
+
 
 ## Examples
 
-| Field | Type | Required    | Description |
-| ----- | ---- | ----------- | ----------- |
-| `location` | [Location](#location) | yes | |
-| `tags` | [Tag](#tag)[] | yes | |
-| `keyword` | string | yes | |
-| `name` | string | yes | |
-| `description` | string | yes | |
-| `tableHeader` | [TableRow](#tablerow) | no | |
-| `tableBody` | [TableRow](#tablerow)[] | yes | |
-| `id` | string | yes | |
+
+
+### .location 
+
+* Type: [Location](#location) 
+* Required: yes 
+
+The location of the `Examples` keyword
+
+### .tags 
+
+* Type: [Tag](#tag)[] 
+* Required: yes 
+
+
+
+### .keyword 
+
+* Type: string 
+* Required: yes 
+
+
+
+### .name 
+
+* Type: string 
+* Required: yes 
+
+
+
+### .description 
+
+* Type: string 
+* Required: yes 
+
+
+
+### .tableHeader 
+
+* Type: [TableRow](#tablerow) 
+* Required: no 
+
+
+
+### .tableBody 
+
+* Type: [TableRow](#tablerow)[] 
+* Required: yes 
+
+
+
+### .id 
+
+* Type: string 
+* Required: yes 
+
+
 
 ## Feature
 
-| Field | Type | Required    | Description |
-| ----- | ---- | ----------- | ----------- |
-| `location` | [Location](#location) | yes | |
-| `tags` | [Tag](#tag)[] | yes | |
-| `language` | string | yes | |
-| `keyword` | string | yes | |
-| `name` | string | yes | |
-| `description` | string | yes | |
-| `children` | [FeatureChild](#featurechild)[] | yes | |
+
+
+### .location 
+
+* Type: [Location](#location) 
+* Required: yes 
+
+The location of the `Feature` keyword
+
+### .tags 
+
+* Type: [Tag](#tag)[] 
+* Required: yes 
+
+All the tags placed above the `Feature` keyword
+
+### .language 
+
+* Type: string 
+* Required: yes 
+
+The [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1) language code of the Gherkin document
+
+### .keyword 
+
+* Type: string 
+* Required: yes 
+
+The text of the `Feature` keyword (in the language specified by `language`)
+
+### .name 
+
+* Type: string 
+* Required: yes 
+
+The name of the feature (the text following the `keyword`)
+
+### .description 
+
+* Type: string 
+* Required: yes 
+
+The line(s) underneath the line with the `keyword` that are used as description
+
+### .children 
+
+* Type: [FeatureChild](#featurechild)[] 
+* Required: yes 
+
+Zero or more children
 
 ## FeatureChild
 
-| Field | Type | Required    | Description |
-| ----- | ---- | ----------- | ----------- |
-| `rule` | [Rule](#rule) | no | |
-| `background` | [Background](#background) | no | |
-| `scenario` | [Scenario](#scenario) | no | |
+A child node of a `Feature` node
+
+### .rule 
+
+* Type: [Rule](#rule) 
+* Required: no 
+
+
+
+### .background 
+
+* Type: [Background](#background) 
+* Required: no 
+
+
+
+### .scenario 
+
+* Type: [Scenario](#scenario) 
+* Required: no 
+
+
 
 ## Rule
 
-| Field | Type | Required    | Description |
-| ----- | ---- | ----------- | ----------- |
-| `location` | [Location](#location) | yes | |
-| `tags` | [Tag](#tag)[] | yes | |
-| `keyword` | string | yes | |
-| `name` | string | yes | |
-| `description` | string | yes | |
-| `children` | [RuleChild](#rulechild)[] | yes | |
-| `id` | string | yes | |
+
+
+### .location 
+
+* Type: [Location](#location) 
+* Required: yes 
+
+The location of the `Rule` keyword
+
+### .tags 
+
+* Type: [Tag](#tag)[] 
+* Required: yes 
+
+All the tags placed above the `Rule` keyword
+
+### .keyword 
+
+* Type: string 
+* Required: yes 
+
+
+
+### .name 
+
+* Type: string 
+* Required: yes 
+
+
+
+### .description 
+
+* Type: string 
+* Required: yes 
+
+
+
+### .children 
+
+* Type: [RuleChild](#rulechild)[] 
+* Required: yes 
+
+
+
+### .id 
+
+* Type: string 
+* Required: yes 
+
+
 
 ## RuleChild
 
-| Field | Type | Required    | Description |
-| ----- | ---- | ----------- | ----------- |
-| `background` | [Background](#background) | no | |
-| `scenario` | [Scenario](#scenario) | no | |
+A child node of a `Rule` node
+
+### .background 
+
+* Type: [Background](#background) 
+* Required: no 
+
+
+
+### .scenario 
+
+* Type: [Scenario](#scenario) 
+* Required: no 
+
+
 
 ## Scenario
 
-| Field | Type | Required    | Description |
-| ----- | ---- | ----------- | ----------- |
-| `location` | [Location](#location) | yes | |
-| `tags` | [Tag](#tag)[] | yes | |
-| `keyword` | string | yes | |
-| `name` | string | yes | |
-| `description` | string | yes | |
-| `steps` | [Step](#step)[] | yes | |
-| `examples` | [Examples](#examples)[] | yes | |
-| `id` | string | yes | |
+
+
+### .location 
+
+* Type: [Location](#location) 
+* Required: yes 
+
+The location of the `Scenario` keyword
+
+### .tags 
+
+* Type: [Tag](#tag)[] 
+* Required: yes 
+
+
+
+### .keyword 
+
+* Type: string 
+* Required: yes 
+
+
+
+### .name 
+
+* Type: string 
+* Required: yes 
+
+
+
+### .description 
+
+* Type: string 
+* Required: yes 
+
+
+
+### .steps 
+
+* Type: [Step](#step)[] 
+* Required: yes 
+
+
+
+### .examples 
+
+* Type: [Examples](#examples)[] 
+* Required: yes 
+
+
+
+### .id 
+
+* Type: string 
+* Required: yes 
+
+
 
 ## Step
 
-| Field | Type | Required    | Description |
-| ----- | ---- | ----------- | ----------- |
-| `location` | [Location](#location) | yes | |
-| `keyword` | string | yes | |
-| `keywordType` | [StepKeywordType](#stepkeywordtype) | no | |
-| `text` | string | yes | |
-| `docString` | [DocString](#docstring) | no | |
-| `dataTable` | [DataTable](#datatable) | no | |
-| `id` | string | yes | |
+A step
+
+### .location 
+
+* Type: [Location](#location) 
+* Required: yes 
+
+The location of the steps' `keyword`
+
+### .keyword 
+
+* Type: string 
+* Required: yes 
+
+The actual keyword as it appeared in the source.
+
+### .keywordType 
+
+* Type: [StepKeywordType](#stepkeywordtype) 
+* Required: no 
+
+The test phase signalled by the keyword: Context definition (Given), Action performance (When), Outcome assertion (Then). Other keywords signal Continuation (And and But) from a prior keyword. Please note that all translations which a dialect maps to multiple keywords (`*` is in this category for all dialects), map to 'Unknown'.
+
+### .text 
+
+* Type: string 
+* Required: yes 
+
+
+
+### .docString 
+
+* Type: [DocString](#docstring) 
+* Required: no 
+
+
+
+### .dataTable 
+
+* Type: [DataTable](#datatable) 
+* Required: no 
+
+
+
+### .id 
+
+* Type: string 
+* Required: yes 
+
+Unique ID to be able to reference the Step from PickleStep
 
 ## TableCell
 
-| Field | Type | Required    | Description |
-| ----- | ---- | ----------- | ----------- |
-| `location` | [Location](#location) | yes | |
-| `value` | string | yes | |
+A cell in a `TableRow`
+
+### .location 
+
+* Type: [Location](#location) 
+* Required: yes 
+
+The location of the cell
+
+### .value 
+
+* Type: string 
+* Required: yes 
+
+The value of the cell
 
 ## TableRow
 
-| Field | Type | Required    | Description |
-| ----- | ---- | ----------- | ----------- |
-| `location` | [Location](#location) | yes | |
-| `cells` | [TableCell](#tablecell)[] | yes | |
-| `id` | string | yes | |
+A row in a table
+
+### .location 
+
+* Type: [Location](#location) 
+* Required: yes 
+
+The location of the first cell in the row
+
+### .cells 
+
+* Type: [TableCell](#tablecell)[] 
+* Required: yes 
+
+Cells in the row
+
+### .id 
+
+* Type: string 
+* Required: yes 
+
+
 
 ## Tag
 
-| Field | Type | Required    | Description |
-| ----- | ---- | ----------- | ----------- |
-| `location` | [Location](#location) | yes | |
-| `name` | string | yes | |
-| `id` | string | yes | |
+A tag
+
+### .location 
+
+* Type: [Location](#location) 
+* Required: yes 
+
+Location of the tag
+
+### .name 
+
+* Type: string 
+* Required: yes 
+
+The name of the tag (including the leading `@`)
+
+### .id 
+
+* Type: string 
+* Required: yes 
+
+Unique ID to be able to reference the Tag from PickleTag
 
 ## Hook
 
-| Field | Type | Required    | Description |
-| ----- | ---- | ----------- | ----------- |
-| `id` | string | yes | |
-| `name` | string | no | |
-| `sourceReference` | [SourceReference](#sourcereference) | yes | |
-| `tagExpression` | string | no | |
-| `type` | [HookType](#hooktype) | no | |
+
+
+### .id 
+
+* Type: string 
+* Required: yes 
+
+
+
+### .name 
+
+* Type: string 
+* Required: no 
+
+
+
+### .sourceReference 
+
+* Type: [SourceReference](#sourcereference) 
+* Required: yes 
+
+
+
+### .tagExpression 
+
+* Type: string 
+* Required: no 
+
+
+
+### .type 
+
+* Type: [HookType](#hooktype) 
+* Required: no 
+
+
 
 ## Location
 
-| Field | Type | Required    | Description |
-| ----- | ---- | ----------- | ----------- |
-| `line` | integer | yes | |
-| `column` | integer | no | |
+Points to a line and a column in a text file
+
+### .line 
+
+* Type: integer 
+* Required: yes 
+
+
+
+### .column 
+
+* Type: integer 
+* Required: no 
+
+
 
 ## Meta
 
-| Field | Type | Required    | Description |
-| ----- | ---- | ----------- | ----------- |
-| `protocolVersion` | string | yes | |
-| `implementation` | [Product](#product) | yes | |
-| `runtime` | [Product](#product) | yes | |
-| `os` | [Product](#product) | yes | |
-| `cpu` | [Product](#product) | yes | |
-| `ci` | [Ci](#ci) | no | |
+This message contains meta information about the environment. Consumers can use
+this for various purposes.
+
+### .protocolVersion 
+
+* Type: string 
+* Required: yes 
+
+The [SEMVER](https://semver.org/) version number of the protocol
+
+### .implementation 
+
+* Type: [Product](#product) 
+* Required: yes 
+
+SpecFlow, Cucumber-JVM, Cucumber.js, Cucumber-Ruby, Behat etc.
+
+### .runtime 
+
+* Type: [Product](#product) 
+* Required: yes 
+
+Java, Ruby, Node.js etc
+
+### .os 
+
+* Type: [Product](#product) 
+* Required: yes 
+
+Windows, Linux, MacOS etc
+
+### .cpu 
+
+* Type: [Product](#product) 
+* Required: yes 
+
+386, arm, amd64 etc
+
+### .ci 
+
+* Type: [Ci](#ci) 
+* Required: no 
+
+
 
 ## Ci
 
-| Field | Type | Required    | Description |
-| ----- | ---- | ----------- | ----------- |
-| `name` | string | yes | |
-| `url` | string | no | |
-| `buildNumber` | string | no | |
-| `git` | [Git](#git) | no | |
+CI environment
+
+### .name 
+
+* Type: string 
+* Required: yes 
+
+Name of the CI product, e.g. "Jenkins", "CircleCI" etc.
+
+### .url 
+
+* Type: string 
+* Required: no 
+
+Link to the build
+
+### .buildNumber 
+
+* Type: string 
+* Required: no 
+
+The build number. Some CI servers use non-numeric build numbers, which is why this is a string
+
+### .git 
+
+* Type: [Git](#git) 
+* Required: no 
+
+
 
 ## Git
 
-| Field | Type | Required    | Description |
-| ----- | ---- | ----------- | ----------- |
-| `remote` | string | yes | |
-| `revision` | string | yes | |
-| `branch` | string | no | |
-| `tag` | string | no | |
+Information about Git, provided by the Build/CI server as environment
+variables.
+
+### .remote 
+
+* Type: string 
+* Required: yes 
+
+
+
+### .revision 
+
+* Type: string 
+* Required: yes 
+
+
+
+### .branch 
+
+* Type: string 
+* Required: no 
+
+
+
+### .tag 
+
+* Type: string 
+* Required: no 
+
+
 
 ## Product
 
-| Field | Type | Required    | Description |
-| ----- | ---- | ----------- | ----------- |
-| `name` | string | yes | |
-| `version` | string | no | |
+Used to describe various properties of Meta
+
+### .name 
+
+* Type: string 
+* Required: yes 
+
+The product name
+
+### .version 
+
+* Type: string 
+* Required: no 
+
+The product version
 
 ## ParameterType
 
-| Field | Type | Required    | Description |
-| ----- | ---- | ----------- | ----------- |
-| `name` | string | yes | |
-| `regularExpressions` | string[] | yes | |
-| `preferForRegularExpressionMatch` | boolean | yes | |
-| `useForSnippets` | boolean | yes | |
-| `id` | string | yes | |
-| `sourceReference` | [SourceReference](#sourcereference) | no | |
+
+
+### .name 
+
+* Type: string 
+* Required: yes 
+
+The name is unique, so we don't need an id.
+
+### .regularExpressions 
+
+* Type: string[] 
+* Required: yes 
+
+
+
+### .preferForRegularExpressionMatch 
+
+* Type: boolean 
+* Required: yes 
+
+
+
+### .useForSnippets 
+
+* Type: boolean 
+* Required: yes 
+
+
+
+### .id 
+
+* Type: string 
+* Required: yes 
+
+
+
+### .sourceReference 
+
+* Type: [SourceReference](#sourcereference) 
+* Required: no 
+
+
 
 ## ParseError
 
-| Field | Type | Required    | Description |
-| ----- | ---- | ----------- | ----------- |
-| `source` | [SourceReference](#sourcereference) | yes | |
-| `message` | string | yes | |
+
+
+### .source 
+
+* Type: [SourceReference](#sourcereference) 
+* Required: yes 
+
+
+
+### .message 
+
+* Type: string 
+* Required: yes 
+
+
 
 ## Pickle
 
-| Field | Type | Required    | Description |
-| ----- | ---- | ----------- | ----------- |
-| `id` | string | yes | |
-| `uri` | string | yes | |
-| `name` | string | yes | |
-| `language` | string | yes | |
-| `steps` | [PickleStep](#picklestep)[] | yes | |
-| `tags` | [PickleTag](#pickletag)[] | yes | |
-| `astNodeIds` | string[] | yes | |
+A `Pickle` represents a template for a `TestCase`. It is typically derived
+from another format, such as [GherkinDocument](#io.cucumber.messages.GherkinDocument).
+In the future a `Pickle` may be derived from other formats such as Markdown or
+Excel files.
+
+By making `Pickle` the main data structure Cucumber uses for execution, the
+implementation of Cucumber itself becomes simpler, as it doesn't have to deal
+with the complex structure of a [GherkinDocument](#io.cucumber.messages.GherkinDocument).
+
+Each `PickleStep` of a `Pickle` is matched with a `StepDefinition` to create a `TestCase`
+
+### .id 
+
+* Type: string 
+* Required: yes 
+
+A unique id for the pickle
+
+### .uri 
+
+* Type: string 
+* Required: yes 
+
+The uri of the source file
+
+### .name 
+
+* Type: string 
+* Required: yes 
+
+The name of the pickle
+
+### .language 
+
+* Type: string 
+* Required: yes 
+
+The language of the pickle
+
+### .steps 
+
+* Type: [PickleStep](#picklestep)[] 
+* Required: yes 
+
+One or more steps
+
+### .tags 
+
+* Type: [PickleTag](#pickletag)[] 
+* Required: yes 
+
+One or more tags. If this pickle is constructed from a Gherkin document,
+It includes inherited tags from the `Feature` as well.
+
+### .astNodeIds 
+
+* Type: string[] 
+* Required: yes 
+
+Points to the AST node locations of the pickle. The last one represents the unique
+id of the pickle. A pickle constructed from `Examples` will have the first
+id originating from the `Scenario` AST node, and the second from the `TableRow` AST node.
 
 ## PickleDocString
 
-| Field | Type | Required    | Description |
-| ----- | ---- | ----------- | ----------- |
-| `mediaType` | string | no | |
-| `content` | string | yes | |
+
+
+### .mediaType 
+
+* Type: string 
+* Required: no 
+
+
+
+### .content 
+
+* Type: string 
+* Required: yes 
+
+
 
 ## PickleStep
 
-| Field | Type | Required    | Description |
-| ----- | ---- | ----------- | ----------- |
-| `argument` | [PickleStepArgument](#picklestepargument) | no | |
-| `astNodeIds` | string[] | yes | |
-| `id` | string | yes | |
-| `type` | [PickleStepType](#picklesteptype) | no | |
-| `text` | string | yes | |
+An executable step
+
+### .argument 
+
+* Type: [PickleStepArgument](#picklestepargument) 
+* Required: no 
+
+
+
+### .astNodeIds 
+
+* Type: string[] 
+* Required: yes 
+
+References the IDs of the source of the step. For Gherkin, this can be
+the ID of a Step, and possibly also the ID of a TableRow
+
+### .id 
+
+* Type: string 
+* Required: yes 
+
+A unique ID for the PickleStep
+
+### .type 
+
+* Type: [PickleStepType](#picklesteptype) 
+* Required: no 
+
+The context in which the step was specified: context (Given), action (When) or outcome (Then).
+
+Note that the keywords `But` and `And` inherit their meaning from prior steps and the `*` 'keyword' doesn't have specific meaning (hence Unknown)
+
+### .text 
+
+* Type: string 
+* Required: yes 
+
+
 
 ## PickleStepArgument
 
-| Field | Type | Required    | Description |
-| ----- | ---- | ----------- | ----------- |
-| `docString` | [PickleDocString](#pickledocstring) | no | |
-| `dataTable` | [PickleTable](#pickletable) | no | |
+An optional argument
+
+### .docString 
+
+* Type: [PickleDocString](#pickledocstring) 
+* Required: no 
+
+
+
+### .dataTable 
+
+* Type: [PickleTable](#pickletable) 
+* Required: no 
+
+
 
 ## PickleTable
 
-| Field | Type | Required    | Description |
-| ----- | ---- | ----------- | ----------- |
-| `rows` | [PickleTableRow](#pickletablerow)[] | yes | |
+
+
+### .rows 
+
+* Type: [PickleTableRow](#pickletablerow)[] 
+* Required: yes 
+
+
 
 ## PickleTableCell
 
-| Field | Type | Required    | Description |
-| ----- | ---- | ----------- | ----------- |
-| `value` | string | yes | |
+
+
+### .value 
+
+* Type: string 
+* Required: yes 
+
+
 
 ## PickleTableRow
 
-| Field | Type | Required    | Description |
-| ----- | ---- | ----------- | ----------- |
-| `cells` | [PickleTableCell](#pickletablecell)[] | yes | |
+
+
+### .cells 
+
+* Type: [PickleTableCell](#pickletablecell)[] 
+* Required: yes 
+
+
 
 ## PickleTag
 
-| Field | Type | Required    | Description |
-| ----- | ---- | ----------- | ----------- |
-| `name` | string | yes | |
-| `astNodeId` | string | yes | |
+A tag
+
+### .name 
+
+* Type: string 
+* Required: yes 
+
+
+
+### .astNodeId 
+
+* Type: string 
+* Required: yes 
+
+Points to the AST node this was created from
 
 ## Source
 
-| Field | Type | Required    | Description |
-| ----- | ---- | ----------- | ----------- |
-| `uri` | string | yes | |
-| `data` | string | yes | |
-| `mediaType` | [SourceMediaType](#sourcemediatype) | yes | |
+A source file, typically a Gherkin document or Java/Ruby/JavaScript source code
+
+### .uri 
+
+* Type: string 
+* Required: yes 
+
+The [URI](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier)
+of the source, typically a file path relative to the root directory
+
+### .data 
+
+* Type: string 
+* Required: yes 
+
+The contents of the file
+
+### .mediaType 
+
+* Type: [SourceMediaType](#sourcemediatype) 
+* Required: yes 
+
+The media type of the file. Can be used to specify custom types, such as
+text/x.cucumber.gherkin+plain
 
 ## SourceReference
 
-| Field | Type | Required    | Description |
-| ----- | ---- | ----------- | ----------- |
-| `uri` | string | no | |
-| `javaMethod` | [JavaMethod](#javamethod) | no | |
-| `javaStackTraceElement` | [JavaStackTraceElement](#javastacktraceelement) | no | |
-| `location` | [Location](#location) | no | |
+Points to a [Source](#io.cucumber.messages.Source) identified by `uri` and a
+[Location](#io.cucumber.messages.Location) within that file.
+
+### .uri 
+
+* Type: string 
+* Required: no 
+
+
+
+### .javaMethod 
+
+* Type: [JavaMethod](#javamethod) 
+* Required: no 
+
+
+
+### .javaStackTraceElement 
+
+* Type: [JavaStackTraceElement](#javastacktraceelement) 
+* Required: no 
+
+
+
+### .location 
+
+* Type: [Location](#location) 
+* Required: no 
+
+
 
 ## JavaMethod
 
-| Field | Type | Required    | Description |
-| ----- | ---- | ----------- | ----------- |
-| `className` | string | yes | |
-| `methodName` | string | yes | |
-| `methodParameterTypes` | string[] | yes | |
+
+
+### .className 
+
+* Type: string 
+* Required: yes 
+
+
+
+### .methodName 
+
+* Type: string 
+* Required: yes 
+
+
+
+### .methodParameterTypes 
+
+* Type: string[] 
+* Required: yes 
+
+
 
 ## JavaStackTraceElement
 
-| Field | Type | Required    | Description |
-| ----- | ---- | ----------- | ----------- |
-| `className` | string | yes | |
-| `fileName` | string | yes | |
-| `methodName` | string | yes | |
+
+
+### .className 
+
+* Type: string 
+* Required: yes 
+
+
+
+### .fileName 
+
+* Type: string 
+* Required: yes 
+
+
+
+### .methodName 
+
+* Type: string 
+* Required: yes 
+
+
 
 ## StepDefinition
 
-| Field | Type | Required    | Description |
-| ----- | ---- | ----------- | ----------- |
-| `id` | string | yes | |
-| `pattern` | [StepDefinitionPattern](#stepdefinitionpattern) | yes | |
-| `sourceReference` | [SourceReference](#sourcereference) | yes | |
+
+
+### .id 
+
+* Type: string 
+* Required: yes 
+
+
+
+### .pattern 
+
+* Type: [StepDefinitionPattern](#stepdefinitionpattern) 
+* Required: yes 
+
+
+
+### .sourceReference 
+
+* Type: [SourceReference](#sourcereference) 
+* Required: yes 
+
+
 
 ## StepDefinitionPattern
 
-| Field | Type | Required    | Description |
-| ----- | ---- | ----------- | ----------- |
-| `source` | string | yes | |
-| `type` | [StepDefinitionPatternType](#stepdefinitionpatterntype) | yes | |
+
+
+### .source 
+
+* Type: string 
+* Required: yes 
+
+
+
+### .type 
+
+* Type: [StepDefinitionPatternType](#stepdefinitionpatterntype) 
+* Required: yes 
+
+
 
 ## TestCase
 
-| Field | Type | Required    | Description |
-| ----- | ---- | ----------- | ----------- |
-| `id` | string | yes | |
-| `pickleId` | string | yes | |
-| `testSteps` | [TestStep](#teststep)[] | yes | |
-| `testRunStartedId` | string | no | |
+A `TestCase` contains a sequence of `TestStep`s.
+
+### .id 
+
+* Type: string 
+* Required: yes 
+
+
+
+### .pickleId 
+
+* Type: string 
+* Required: yes 
+
+The ID of the `Pickle` this `TestCase` is derived from.
+
+### .testSteps 
+
+* Type: [TestStep](#teststep)[] 
+* Required: yes 
+
+
+
+### .testRunStartedId 
+
+* Type: string 
+* Required: no 
+
+Identifier for the test run that this test case belongs to
 
 ## Group
 
-| Field | Type | Required    | Description |
-| ----- | ---- | ----------- | ----------- |
-| `children` | [Group](#group)[] | yes | |
-| `start` | integer | no | |
-| `value` | string | no | |
+
+
+### .children 
+
+* Type: [Group](#group)[] 
+* Required: yes 
+
+
+
+### .start 
+
+* Type: integer 
+* Required: no 
+
+
+
+### .value 
+
+* Type: string 
+* Required: no 
+
+
 
 ## StepMatchArgument
 
-| Field | Type | Required    | Description |
-| ----- | ---- | ----------- | ----------- |
-| `group` | [Group](#group) | yes | |
-| `parameterTypeName` | string | no | |
+Represents a single argument extracted from a step match and passed to a step definition.
+This is used for the following purposes:
+- Construct an argument to pass to a step definition (possibly through a parameter type transform)
+- Highlight the matched parameter in rich formatters such as the HTML formatter
+
+This message closely matches the `Argument` class in the `cucumber-expressions` library.
+
+### .group 
+
+* Type: [Group](#group) 
+* Required: yes 
+
+Represents the outermost capture group of an argument. This message closely matches the
+`Group` class in the `cucumber-expressions` library.
+
+### .parameterTypeName 
+
+* Type: string 
+* Required: no 
+
+
 
 ## StepMatchArgumentsList
 
-| Field | Type | Required    | Description |
-| ----- | ---- | ----------- | ----------- |
-| `stepMatchArguments` | [StepMatchArgument](#stepmatchargument)[] | yes | |
+
+
+### .stepMatchArguments 
+
+* Type: [StepMatchArgument](#stepmatchargument)[] 
+* Required: yes 
+
+
 
 ## TestStep
 
-| Field | Type | Required    | Description |
-| ----- | ---- | ----------- | ----------- |
-| `hookId` | string | no | |
-| `id` | string | yes | |
-| `pickleStepId` | string | no | |
-| `stepDefinitionIds` | string[] | no | |
-| `stepMatchArgumentsLists` | [StepMatchArgumentsList](#stepmatchargumentslist)[] | no | |
+A `TestStep` is derived from either a `PickleStep`
+combined with a `StepDefinition`, or from a `Hook`.
+
+### .hookId 
+
+* Type: string 
+* Required: no 
+
+Pointer to the `Hook` (if derived from a Hook)
+
+### .id 
+
+* Type: string 
+* Required: yes 
+
+
+
+### .pickleStepId 
+
+* Type: string 
+* Required: no 
+
+Pointer to the `PickleStep` (if derived from a `PickleStep`)
+
+### .stepDefinitionIds 
+
+* Type: string[] 
+* Required: no 
+
+Pointer to all the matching `StepDefinition`s (if derived from a `PickleStep`)
+Each element represents a matching step definition. A size of 0 means `UNDEFINED`,
+and a size of 2+ means `AMBIGUOUS`
+
+### .stepMatchArgumentsLists 
+
+* Type: [StepMatchArgumentsList](#stepmatchargumentslist)[] 
+* Required: no 
+
+A list of list of StepMatchArgument (if derived from a `PickleStep`).
 
 ## TestCaseFinished
 
-| Field | Type | Required    | Description |
-| ----- | ---- | ----------- | ----------- |
-| `testCaseStartedId` | string | yes | |
-| `timestamp` | [Timestamp](#timestamp) | yes | |
-| `willBeRetried` | boolean | yes | |
+
+
+### .testCaseStartedId 
+
+* Type: string 
+* Required: yes 
+
+
+
+### .timestamp 
+
+* Type: [Timestamp](#timestamp) 
+* Required: yes 
+
+
+
+### .willBeRetried 
+
+* Type: boolean 
+* Required: yes 
+
+
 
 ## TestCaseStarted
 
-| Field | Type | Required    | Description |
-| ----- | ---- | ----------- | ----------- |
-| `attempt` | integer | yes | |
-| `id` | string | yes | |
-| `testCaseId` | string | yes | |
-| `workerId` | string | no | |
-| `timestamp` | [Timestamp](#timestamp) | yes | |
+
+
+### .attempt 
+
+* Type: integer 
+* Required: yes 
+
+The first attempt should have value 0, and for each retry the value
+should increase by 1.
+
+### .id 
+
+* Type: string 
+* Required: yes 
+
+Because a `TestCase` can be run multiple times (in case of a retry),
+we use this field to group messages relating to the same attempt.
+
+### .testCaseId 
+
+* Type: string 
+* Required: yes 
+
+
+
+### .workerId 
+
+* Type: string 
+* Required: no 
+
+An identifier for the worker process running this test case, if test cases are being run in parallel. The identifier will be unique per worker, but no particular format is defined - it could be an index, uuid, machine name etc - and as such should be assumed that it's not human readable.
+
+### .timestamp 
+
+* Type: [Timestamp](#timestamp) 
+* Required: yes 
+
+
 
 ## TestRunFinished
 
-| Field | Type | Required    | Description |
-| ----- | ---- | ----------- | ----------- |
-| `message` | string | no | |
-| `success` | boolean | yes | |
-| `timestamp` | [Timestamp](#timestamp) | yes | |
-| `exception` | [Exception](#exception) | no | |
-| `testRunStartedId` | string | no | |
+
+
+### .message 
+
+* Type: string 
+* Required: no 
+
+An informative message about the test run. Typically additional information about failure, but not necessarily.
+
+### .success 
+
+* Type: boolean 
+* Required: yes 
+
+A test run is successful if all steps are either passed or skipped, all before/after hooks passed and no other exceptions where thrown.
+
+### .timestamp 
+
+* Type: [Timestamp](#timestamp) 
+* Required: yes 
+
+Timestamp when the TestRun is finished
+
+### .exception 
+
+* Type: [Exception](#exception) 
+* Required: no 
+
+Any exception thrown during the test run, if any. Does not include exceptions thrown while executing steps.
+
+### .testRunStartedId 
+
+* Type: string 
+* Required: no 
+
+
 
 ## TestRunHookFinished
 
-| Field | Type | Required    | Description |
-| ----- | ---- | ----------- | ----------- |
-| `testRunHookStartedId` | string | yes | |
-| `result` | [TestStepResult](#teststepresult) | yes | |
-| `timestamp` | [Timestamp](#timestamp) | yes | |
+
+
+### .testRunHookStartedId 
+
+* Type: string 
+* Required: yes 
+
+Identifier for the hook execution that has finished
+
+### .result 
+
+* Type: [TestStepResult](#teststepresult) 
+* Required: yes 
+
+
+
+### .timestamp 
+
+* Type: [Timestamp](#timestamp) 
+* Required: yes 
+
+
 
 ## TestRunHookStarted
 
-| Field | Type | Required    | Description |
-| ----- | ---- | ----------- | ----------- |
-| `id` | string | yes | |
-| `testRunStartedId` | string | yes | |
-| `hookId` | string | yes | |
-| `timestamp` | [Timestamp](#timestamp) | yes | |
+
+
+### .id 
+
+* Type: string 
+* Required: yes 
+
+Unique identifier for this hook execution
+
+### .testRunStartedId 
+
+* Type: string 
+* Required: yes 
+
+Identifier for the test run that this hook execution belongs to
+
+### .hookId 
+
+* Type: string 
+* Required: yes 
+
+Identifier for the hook that will be executed
+
+### .timestamp 
+
+* Type: [Timestamp](#timestamp) 
+* Required: yes 
+
+
 
 ## TestRunStarted
 
-| Field | Type | Required    | Description |
-| ----- | ---- | ----------- | ----------- |
-| `timestamp` | [Timestamp](#timestamp) | yes | |
-| `id` | string | no | |
+
+
+### .timestamp 
+
+* Type: [Timestamp](#timestamp) 
+* Required: yes 
+
+
+
+### .id 
+
+* Type: string 
+* Required: no 
+
+
 
 ## TestStepFinished
 
-| Field | Type | Required    | Description |
-| ----- | ---- | ----------- | ----------- |
-| `testCaseStartedId` | string | yes | |
-| `testStepId` | string | yes | |
-| `testStepResult` | [TestStepResult](#teststepresult) | yes | |
-| `timestamp` | [Timestamp](#timestamp) | yes | |
+
+
+### .testCaseStartedId 
+
+* Type: string 
+* Required: yes 
+
+
+
+### .testStepId 
+
+* Type: string 
+* Required: yes 
+
+
+
+### .testStepResult 
+
+* Type: [TestStepResult](#teststepresult) 
+* Required: yes 
+
+
+
+### .timestamp 
+
+* Type: [Timestamp](#timestamp) 
+* Required: yes 
+
+
 
 ## TestStepResult
 
-| Field | Type | Required    | Description |
-| ----- | ---- | ----------- | ----------- |
-| `duration` | [Duration](#duration) | yes | |
-| `message` | string | no | |
-| `status` | [TestStepResultStatus](#teststepresultstatus) | yes | |
-| `exception` | [Exception](#exception) | no | |
+
+
+### .duration 
+
+* Type: [Duration](#duration) 
+* Required: yes 
+
+
+
+### .message 
+
+* Type: string 
+* Required: no 
+
+An arbitrary bit of information that explains this result. If there was an exception, this should include a stringified representation of it including type, message and stack trace (the exact format will vary by platform).
+
+### .status 
+
+* Type: [TestStepResultStatus](#teststepresultstatus) 
+* Required: yes 
+
+
+
+### .exception 
+
+* Type: [Exception](#exception) 
+* Required: no 
+
+Exception thrown while executing this step, if any.
 
 ## TestStepStarted
 
-| Field | Type | Required    | Description |
-| ----- | ---- | ----------- | ----------- |
-| `testCaseStartedId` | string | yes | |
-| `testStepId` | string | yes | |
-| `timestamp` | [Timestamp](#timestamp) | yes | |
+
+
+### .testCaseStartedId 
+
+* Type: string 
+* Required: yes 
+
+
+
+### .testStepId 
+
+* Type: string 
+* Required: yes 
+
+
+
+### .timestamp 
+
+* Type: [Timestamp](#timestamp) 
+* Required: yes 
+
+
 
 ## Timestamp
 
-| Field | Type | Required    | Description |
-| ----- | ---- | ----------- | ----------- |
-| `seconds` | integer | yes | |
-| `nanos` | integer | yes | |
+
+
+### .seconds 
+
+* Type: integer 
+* Required: yes 
+
+Represents seconds of UTC time since Unix epoch
+1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
+9999-12-31T23:59:59Z inclusive.
+
+### .nanos 
+
+* Type: integer 
+* Required: yes 
+
+Non-negative fractions of a second at nanosecond resolution. Negative
+second values with fractions must still have non-negative nanos values
+that count forward in time. Must be from 0 to 999,999,999
+inclusive.
 
 ## UndefinedParameterType
 
-| Field | Type | Required    | Description |
-| ----- | ---- | ----------- | ----------- |
-| `expression` | string | yes | |
-| `name` | string | yes | |
+
+
+### .expression 
+
+* Type: string 
+* Required: yes 
+
+
+
+### .name 
+
+* Type: string 
+* Required: yes 
+
+
 
 ## AttachmentContentEncoding
 


### PR DESCRIPTION
### 🤔 What's changed?

Updated the markdown template to include the object and field
descriptions of all messages.
Because descriptions contain multi-line strings this doesn't work well
with the table format. But we can replicate the effect using headers at
different levels.

Note: Every property is prefixed with a `.` to ensure message names are
unique and Markdown links keep working.

### ⚡️ What's your motivation? 

 This makes it a bit easier to understand
what the messages in the protocol are about.


### 🏷️ What kind of change is this?

- :book: Documentation (improvements without changing code)


### 📋 Checklist:


- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
