### PR TITLE
Use unambiguous anchors in documentation

### DIFF
--- a/codegen/templates/markdown.md.erb
+++ b/codegen/templates/markdown.md.erb
@@ -14,7 +14,7 @@ will only have one of its fields set, which indicates the payload of the message
   description = ( property['description'] || '')
   -%>
 
-### <%= class_name(key) %>.<%= property_name %> 
+#### <%= class_name(key) %>.<%= property_name %> 
 
 * Type: <%= type_name %> 
 * Required: <%= required ? 'yes' : 'no' %> 

--- a/jsonschema/messages.md
+++ b/jsonschema/messages.md
@@ -17,7 +17,7 @@ An attachment represents any kind of data associated with a line in a
 It is not to be used for runtime errors raised/thrown during execution. This
 is captured in `TestResult`.
 
-### Attachment.body 
+#### Attachment.body 
 
 * Type: string 
 * Required: yes 
@@ -26,7 +26,7 @@ The body of the attachment. If `contentEncoding` is `IDENTITY`, the attachment
 is simply the string. If it's `BASE64`, the string should be Base64 decoded to
 obtain the attachment.
 
-### Attachment.contentEncoding 
+#### Attachment.contentEncoding 
 
 * Type: [AttachmentContentEncoding](#attachmentcontentencoding) 
 * Required: yes 
@@ -40,14 +40,14 @@ of the object being attached:
 - byte array: BASE64
 - stream: BASE64
 
-### Attachment.fileName 
+#### Attachment.fileName 
 
 * Type: string 
 * Required: no 
 
 Suggested file name of the attachment. (Provided by the user as an argument to `attach`)
 
-### Attachment.mediaType 
+#### Attachment.mediaType 
 
 * Type: string 
 * Required: yes 
@@ -57,28 +57,28 @@ The media type of the data. This can be any valid
 as well as Cucumber-specific media types such as `text/x.cucumber.gherkin+plain`
 and `text/x.cucumber.stacktrace+plain`
 
-### Attachment.source 
+#### Attachment.source 
 
 * Type: [Source](#source) 
 * Required: no 
 
 
 
-### Attachment.testCaseStartedId 
+#### Attachment.testCaseStartedId 
 
 * Type: string 
 * Required: no 
 
 The identifier of the test case attempt if the attachment was created during the execution of a test step
 
-### Attachment.testStepId 
+#### Attachment.testStepId 
 
 * Type: string 
 * Required: no 
 
 The identifier of the test step if the attachment was created during the execution of a test step
 
-### Attachment.url 
+#### Attachment.url 
 
 * Type: string 
 * Required: no 
@@ -95,21 +95,21 @@ This will result in a smaller message stream, which can improve performance and
 reduce bandwidth of message consumers. It also makes it easier to process and download attachments
 separately from reports.
 
-### Attachment.testRunStartedId 
+#### Attachment.testRunStartedId 
 
 * Type: string 
 * Required: no 
 
 Not used; implementers should instead populate `testRunHookStartedId` if an attachment was created during the execution of a test run hook
 
-### Attachment.testRunHookStartedId 
+#### Attachment.testRunHookStartedId 
 
 * Type: string 
 * Required: no 
 
 The identifier of the test run hook execution if the attachment was created during the execution of a test run hook
 
-### Attachment.timestamp 
+#### Attachment.timestamp 
 
 * Type: [Timestamp](#timestamp) 
 * Required: no 
@@ -121,14 +121,14 @@ When the attachment was created
 The structure is pretty close of the Timestamp one. For clarity, a second type
 of message is used.
 
-### Duration.seconds 
+#### Duration.seconds 
 
 * Type: integer 
 * Required: yes 
 
 
 
-### Duration.nanos 
+#### Duration.nanos 
 
 * Type: integer 
 * Required: yes 
@@ -142,133 +142,133 @@ inclusive.
 
 
 
-### Envelope.attachment 
+#### Envelope.attachment 
 
 * Type: [Attachment](#attachment) 
 * Required: no 
 
 
 
-### Envelope.gherkinDocument 
+#### Envelope.gherkinDocument 
 
 * Type: [GherkinDocument](#gherkindocument) 
 * Required: no 
 
 
 
-### Envelope.hook 
+#### Envelope.hook 
 
 * Type: [Hook](#hook) 
 * Required: no 
 
 
 
-### Envelope.meta 
+#### Envelope.meta 
 
 * Type: [Meta](#meta) 
 * Required: no 
 
 
 
-### Envelope.parameterType 
+#### Envelope.parameterType 
 
 * Type: [ParameterType](#parametertype) 
 * Required: no 
 
 
 
-### Envelope.parseError 
+#### Envelope.parseError 
 
 * Type: [ParseError](#parseerror) 
 * Required: no 
 
 
 
-### Envelope.pickle 
+#### Envelope.pickle 
 
 * Type: [Pickle](#pickle) 
 * Required: no 
 
 
 
-### Envelope.source 
+#### Envelope.source 
 
 * Type: [Source](#source) 
 * Required: no 
 
 
 
-### Envelope.stepDefinition 
+#### Envelope.stepDefinition 
 
 * Type: [StepDefinition](#stepdefinition) 
 * Required: no 
 
 
 
-### Envelope.testCase 
+#### Envelope.testCase 
 
 * Type: [TestCase](#testcase) 
 * Required: no 
 
 
 
-### Envelope.testCaseFinished 
+#### Envelope.testCaseFinished 
 
 * Type: [TestCaseFinished](#testcasefinished) 
 * Required: no 
 
 
 
-### Envelope.testCaseStarted 
+#### Envelope.testCaseStarted 
 
 * Type: [TestCaseStarted](#testcasestarted) 
 * Required: no 
 
 
 
-### Envelope.testRunFinished 
+#### Envelope.testRunFinished 
 
 * Type: [TestRunFinished](#testrunfinished) 
 * Required: no 
 
 
 
-### Envelope.testRunStarted 
+#### Envelope.testRunStarted 
 
 * Type: [TestRunStarted](#testrunstarted) 
 * Required: no 
 
 
 
-### Envelope.testStepFinished 
+#### Envelope.testStepFinished 
 
 * Type: [TestStepFinished](#teststepfinished) 
 * Required: no 
 
 
 
-### Envelope.testStepStarted 
+#### Envelope.testStepStarted 
 
 * Type: [TestStepStarted](#teststepstarted) 
 * Required: no 
 
 
 
-### Envelope.testRunHookStarted 
+#### Envelope.testRunHookStarted 
 
 * Type: [TestRunHookStarted](#testrunhookstarted) 
 * Required: no 
 
 
 
-### Envelope.testRunHookFinished 
+#### Envelope.testRunHookFinished 
 
 * Type: [TestRunHookFinished](#testrunhookfinished) 
 * Required: no 
 
 
 
-### Envelope.undefinedParameterType 
+#### Envelope.undefinedParameterType 
 
 * Type: [UndefinedParameterType](#undefinedparametertype) 
 * Required: no 
@@ -279,21 +279,21 @@ inclusive.
 
 A simplified representation of an exception
 
-### Exception.type 
+#### Exception.type 
 
 * Type: string 
 * Required: yes 
 
 The type of the exception that caused this result. E.g. "Error" or "org.opentest4j.AssertionFailedError"
 
-### Exception.message 
+#### Exception.message 
 
 * Type: string 
 * Required: no 
 
 The message of exception that caused this result. E.g. expected: "a" but was: "b"
 
-### Exception.stackTrace 
+#### Exception.stackTrace 
 
 * Type: string 
 * Required: no 
@@ -309,7 +309,7 @@ children for execution - use [Pickle](#io.cucumber.messages.Pickle) instead.
 The only consumers of `GherkinDocument` should only be formatters that produce
 "rich" output, resembling the original Gherkin document.
 
-### GherkinDocument.uri 
+#### GherkinDocument.uri 
 
 * Type: string 
 * Required: no 
@@ -317,14 +317,14 @@ The only consumers of `GherkinDocument` should only be formatters that produce
 The [URI](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier)
 of the source, typically a file path relative to the root directory
 
-### GherkinDocument.feature 
+#### GherkinDocument.feature 
 
 * Type: [Feature](#feature) 
 * Required: no 
 
 
 
-### GherkinDocument.comments 
+#### GherkinDocument.comments 
 
 * Type: [Comment](#comment)[] 
 * Required: yes 
@@ -335,42 +335,42 @@ All the comments in the Gherkin document
 
 
 
-### Background.location 
+#### Background.location 
 
 * Type: [Location](#location) 
 * Required: yes 
 
 The location of the `Background` keyword
 
-### Background.keyword 
+#### Background.keyword 
 
 * Type: string 
 * Required: yes 
 
 
 
-### Background.name 
+#### Background.name 
 
 * Type: string 
 * Required: yes 
 
 
 
-### Background.description 
+#### Background.description 
 
 * Type: string 
 * Required: yes 
 
 
 
-### Background.steps 
+#### Background.steps 
 
 * Type: [Step](#step)[] 
 * Required: yes 
 
 
 
-### Background.id 
+#### Background.id 
 
 * Type: string 
 * Required: yes 
@@ -381,14 +381,14 @@ The location of the `Background` keyword
 
 A comment in a Gherkin document
 
-### Comment.location 
+#### Comment.location 
 
 * Type: [Location](#location) 
 * Required: yes 
 
 The location of the comment
 
-### Comment.text 
+#### Comment.text 
 
 * Type: string 
 * Required: yes 
@@ -399,14 +399,14 @@ The text of the comment
 
 
 
-### DataTable.location 
+#### DataTable.location 
 
 * Type: [Location](#location) 
 * Required: yes 
 
 
 
-### DataTable.rows 
+#### DataTable.rows 
 
 * Type: [TableRow](#tablerow)[] 
 * Required: yes 
@@ -417,28 +417,28 @@ The text of the comment
 
 
 
-### DocString.location 
+#### DocString.location 
 
 * Type: [Location](#location) 
 * Required: yes 
 
 
 
-### DocString.mediaType 
+#### DocString.mediaType 
 
 * Type: string 
 * Required: no 
 
 
 
-### DocString.content 
+#### DocString.content 
 
 * Type: string 
 * Required: yes 
 
 
 
-### DocString.delimiter 
+#### DocString.delimiter 
 
 * Type: string 
 * Required: yes 
@@ -449,56 +449,56 @@ The text of the comment
 
 
 
-### Examples.location 
+#### Examples.location 
 
 * Type: [Location](#location) 
 * Required: yes 
 
 The location of the `Examples` keyword
 
-### Examples.tags 
+#### Examples.tags 
 
 * Type: [Tag](#tag)[] 
 * Required: yes 
 
 
 
-### Examples.keyword 
+#### Examples.keyword 
 
 * Type: string 
 * Required: yes 
 
 
 
-### Examples.name 
+#### Examples.name 
 
 * Type: string 
 * Required: yes 
 
 
 
-### Examples.description 
+#### Examples.description 
 
 * Type: string 
 * Required: yes 
 
 
 
-### Examples.tableHeader 
+#### Examples.tableHeader 
 
 * Type: [TableRow](#tablerow) 
 * Required: no 
 
 
 
-### Examples.tableBody 
+#### Examples.tableBody 
 
 * Type: [TableRow](#tablerow)[] 
 * Required: yes 
 
 
 
-### Examples.id 
+#### Examples.id 
 
 * Type: string 
 * Required: yes 
@@ -509,49 +509,49 @@ The location of the `Examples` keyword
 
 
 
-### Feature.location 
+#### Feature.location 
 
 * Type: [Location](#location) 
 * Required: yes 
 
 The location of the `Feature` keyword
 
-### Feature.tags 
+#### Feature.tags 
 
 * Type: [Tag](#tag)[] 
 * Required: yes 
 
 All the tags placed above the `Feature` keyword
 
-### Feature.language 
+#### Feature.language 
 
 * Type: string 
 * Required: yes 
 
 The [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1) language code of the Gherkin document
 
-### Feature.keyword 
+#### Feature.keyword 
 
 * Type: string 
 * Required: yes 
 
 The text of the `Feature` keyword (in the language specified by `language`)
 
-### Feature.name 
+#### Feature.name 
 
 * Type: string 
 * Required: yes 
 
 The name of the feature (the text following the `keyword`)
 
-### Feature.description 
+#### Feature.description 
 
 * Type: string 
 * Required: yes 
 
 The line(s) underneath the line with the `keyword` that are used as description
 
-### Feature.children 
+#### Feature.children 
 
 * Type: [FeatureChild](#featurechild)[] 
 * Required: yes 
@@ -562,21 +562,21 @@ Zero or more children
 
 A child node of a `Feature` node
 
-### FeatureChild.rule 
+#### FeatureChild.rule 
 
 * Type: [Rule](#rule) 
 * Required: no 
 
 
 
-### FeatureChild.background 
+#### FeatureChild.background 
 
 * Type: [Background](#background) 
 * Required: no 
 
 
 
-### FeatureChild.scenario 
+#### FeatureChild.scenario 
 
 * Type: [Scenario](#scenario) 
 * Required: no 
@@ -587,49 +587,49 @@ A child node of a `Feature` node
 
 
 
-### Rule.location 
+#### Rule.location 
 
 * Type: [Location](#location) 
 * Required: yes 
 
 The location of the `Rule` keyword
 
-### Rule.tags 
+#### Rule.tags 
 
 * Type: [Tag](#tag)[] 
 * Required: yes 
 
 All the tags placed above the `Rule` keyword
 
-### Rule.keyword 
+#### Rule.keyword 
 
 * Type: string 
 * Required: yes 
 
 
 
-### Rule.name 
+#### Rule.name 
 
 * Type: string 
 * Required: yes 
 
 
 
-### Rule.description 
+#### Rule.description 
 
 * Type: string 
 * Required: yes 
 
 
 
-### Rule.children 
+#### Rule.children 
 
 * Type: [RuleChild](#rulechild)[] 
 * Required: yes 
 
 
 
-### Rule.id 
+#### Rule.id 
 
 * Type: string 
 * Required: yes 
@@ -640,14 +640,14 @@ All the tags placed above the `Rule` keyword
 
 A child node of a `Rule` node
 
-### RuleChild.background 
+#### RuleChild.background 
 
 * Type: [Background](#background) 
 * Required: no 
 
 
 
-### RuleChild.scenario 
+#### RuleChild.scenario 
 
 * Type: [Scenario](#scenario) 
 * Required: no 
@@ -658,56 +658,56 @@ A child node of a `Rule` node
 
 
 
-### Scenario.location 
+#### Scenario.location 
 
 * Type: [Location](#location) 
 * Required: yes 
 
 The location of the `Scenario` keyword
 
-### Scenario.tags 
+#### Scenario.tags 
 
 * Type: [Tag](#tag)[] 
 * Required: yes 
 
 
 
-### Scenario.keyword 
+#### Scenario.keyword 
 
 * Type: string 
 * Required: yes 
 
 
 
-### Scenario.name 
+#### Scenario.name 
 
 * Type: string 
 * Required: yes 
 
 
 
-### Scenario.description 
+#### Scenario.description 
 
 * Type: string 
 * Required: yes 
 
 
 
-### Scenario.steps 
+#### Scenario.steps 
 
 * Type: [Step](#step)[] 
 * Required: yes 
 
 
 
-### Scenario.examples 
+#### Scenario.examples 
 
 * Type: [Examples](#examples)[] 
 * Required: yes 
 
 
 
-### Scenario.id 
+#### Scenario.id 
 
 * Type: string 
 * Required: yes 
@@ -718,49 +718,49 @@ The location of the `Scenario` keyword
 
 A step
 
-### Step.location 
+#### Step.location 
 
 * Type: [Location](#location) 
 * Required: yes 
 
 The location of the steps' `keyword`
 
-### Step.keyword 
+#### Step.keyword 
 
 * Type: string 
 * Required: yes 
 
 The actual keyword as it appeared in the source.
 
-### Step.keywordType 
+#### Step.keywordType 
 
 * Type: [StepKeywordType](#stepkeywordtype) 
 * Required: no 
 
 The test phase signalled by the keyword: Context definition (Given), Action performance (When), Outcome assertion (Then). Other keywords signal Continuation (And and But) from a prior keyword. Please note that all translations which a dialect maps to multiple keywords (`*` is in this category for all dialects), map to 'Unknown'.
 
-### Step.text 
+#### Step.text 
 
 * Type: string 
 * Required: yes 
 
 
 
-### Step.docString 
+#### Step.docString 
 
 * Type: [DocString](#docstring) 
 * Required: no 
 
 
 
-### Step.dataTable 
+#### Step.dataTable 
 
 * Type: [DataTable](#datatable) 
 * Required: no 
 
 
 
-### Step.id 
+#### Step.id 
 
 * Type: string 
 * Required: yes 
@@ -771,14 +771,14 @@ Unique ID to be able to reference the Step from PickleStep
 
 A cell in a `TableRow`
 
-### TableCell.location 
+#### TableCell.location 
 
 * Type: [Location](#location) 
 * Required: yes 
 
 The location of the cell
 
-### TableCell.value 
+#### TableCell.value 
 
 * Type: string 
 * Required: yes 
@@ -789,21 +789,21 @@ The value of the cell
 
 A row in a table
 
-### TableRow.location 
+#### TableRow.location 
 
 * Type: [Location](#location) 
 * Required: yes 
 
 The location of the first cell in the row
 
-### TableRow.cells 
+#### TableRow.cells 
 
 * Type: [TableCell](#tablecell)[] 
 * Required: yes 
 
 Cells in the row
 
-### TableRow.id 
+#### TableRow.id 
 
 * Type: string 
 * Required: yes 
@@ -814,21 +814,21 @@ Cells in the row
 
 A tag
 
-### Tag.location 
+#### Tag.location 
 
 * Type: [Location](#location) 
 * Required: yes 
 
 Location of the tag
 
-### Tag.name 
+#### Tag.name 
 
 * Type: string 
 * Required: yes 
 
 The name of the tag (including the leading `@`)
 
-### Tag.id 
+#### Tag.id 
 
 * Type: string 
 * Required: yes 
@@ -839,35 +839,35 @@ Unique ID to be able to reference the Tag from PickleTag
 
 
 
-### Hook.id 
+#### Hook.id 
 
 * Type: string 
 * Required: yes 
 
 
 
-### Hook.name 
+#### Hook.name 
 
 * Type: string 
 * Required: no 
 
 
 
-### Hook.sourceReference 
+#### Hook.sourceReference 
 
 * Type: [SourceReference](#sourcereference) 
 * Required: yes 
 
 
 
-### Hook.tagExpression 
+#### Hook.tagExpression 
 
 * Type: string 
 * Required: no 
 
 
 
-### Hook.type 
+#### Hook.type 
 
 * Type: [HookType](#hooktype) 
 * Required: no 
@@ -878,14 +878,14 @@ Unique ID to be able to reference the Tag from PickleTag
 
 Points to a line and a column in a text file
 
-### Location.line 
+#### Location.line 
 
 * Type: integer 
 * Required: yes 
 
 
 
-### Location.column 
+#### Location.column 
 
 * Type: integer 
 * Required: no 
@@ -897,42 +897,42 @@ Points to a line and a column in a text file
 This message contains meta information about the environment. Consumers can use
 this for various purposes.
 
-### Meta.protocolVersion 
+#### Meta.protocolVersion 
 
 * Type: string 
 * Required: yes 
 
 The [SEMVER](https://semver.org/) version number of the protocol
 
-### Meta.implementation 
+#### Meta.implementation 
 
 * Type: [Product](#product) 
 * Required: yes 
 
 SpecFlow, Cucumber-JVM, Cucumber.js, Cucumber-Ruby, Behat etc.
 
-### Meta.runtime 
+#### Meta.runtime 
 
 * Type: [Product](#product) 
 * Required: yes 
 
 Java, Ruby, Node.js etc
 
-### Meta.os 
+#### Meta.os 
 
 * Type: [Product](#product) 
 * Required: yes 
 
 Windows, Linux, MacOS etc
 
-### Meta.cpu 
+#### Meta.cpu 
 
 * Type: [Product](#product) 
 * Required: yes 
 
 386, arm, amd64 etc
 
-### Meta.ci 
+#### Meta.ci 
 
 * Type: [Ci](#ci) 
 * Required: no 
@@ -943,28 +943,28 @@ Windows, Linux, MacOS etc
 
 CI environment
 
-### Ci.name 
+#### Ci.name 
 
 * Type: string 
 * Required: yes 
 
 Name of the CI product, e.g. "Jenkins", "CircleCI" etc.
 
-### Ci.url 
+#### Ci.url 
 
 * Type: string 
 * Required: no 
 
 Link to the build
 
-### Ci.buildNumber 
+#### Ci.buildNumber 
 
 * Type: string 
 * Required: no 
 
 The build number. Some CI servers use non-numeric build numbers, which is why this is a string
 
-### Ci.git 
+#### Ci.git 
 
 * Type: [Git](#git) 
 * Required: no 
@@ -976,28 +976,28 @@ The build number. Some CI servers use non-numeric build numbers, which is why th
 Information about Git, provided by the Build/CI server as environment
 variables.
 
-### Git.remote 
+#### Git.remote 
 
 * Type: string 
 * Required: yes 
 
 
 
-### Git.revision 
+#### Git.revision 
 
 * Type: string 
 * Required: yes 
 
 
 
-### Git.branch 
+#### Git.branch 
 
 * Type: string 
 * Required: no 
 
 
 
-### Git.tag 
+#### Git.tag 
 
 * Type: string 
 * Required: no 
@@ -1008,14 +1008,14 @@ variables.
 
 Used to describe various properties of Meta
 
-### Product.name 
+#### Product.name 
 
 * Type: string 
 * Required: yes 
 
 The product name
 
-### Product.version 
+#### Product.version 
 
 * Type: string 
 * Required: no 
@@ -1026,42 +1026,42 @@ The product version
 
 
 
-### ParameterType.name 
+#### ParameterType.name 
 
 * Type: string 
 * Required: yes 
 
 The name is unique, so we don't need an id.
 
-### ParameterType.regularExpressions 
+#### ParameterType.regularExpressions 
 
 * Type: string[] 
 * Required: yes 
 
 
 
-### ParameterType.preferForRegularExpressionMatch 
+#### ParameterType.preferForRegularExpressionMatch 
 
 * Type: boolean 
 * Required: yes 
 
 
 
-### ParameterType.useForSnippets 
+#### ParameterType.useForSnippets 
 
 * Type: boolean 
 * Required: yes 
 
 
 
-### ParameterType.id 
+#### ParameterType.id 
 
 * Type: string 
 * Required: yes 
 
 
 
-### ParameterType.sourceReference 
+#### ParameterType.sourceReference 
 
 * Type: [SourceReference](#sourcereference) 
 * Required: no 
@@ -1072,14 +1072,14 @@ The name is unique, so we don't need an id.
 
 
 
-### ParseError.source 
+#### ParseError.source 
 
 * Type: [SourceReference](#sourcereference) 
 * Required: yes 
 
 
 
-### ParseError.message 
+#### ParseError.message 
 
 * Type: string 
 * Required: yes 
@@ -1099,42 +1099,42 @@ with the complex structure of a [GherkinDocument](#io.cucumber.messages.GherkinD
 
 Each `PickleStep` of a `Pickle` is matched with a `StepDefinition` to create a `TestCase`
 
-### Pickle.id 
+#### Pickle.id 
 
 * Type: string 
 * Required: yes 
 
 A unique id for the pickle
 
-### Pickle.uri 
+#### Pickle.uri 
 
 * Type: string 
 * Required: yes 
 
 The uri of the source file
 
-### Pickle.name 
+#### Pickle.name 
 
 * Type: string 
 * Required: yes 
 
 The name of the pickle
 
-### Pickle.language 
+#### Pickle.language 
 
 * Type: string 
 * Required: yes 
 
 The language of the pickle
 
-### Pickle.steps 
+#### Pickle.steps 
 
 * Type: [PickleStep](#picklestep)[] 
 * Required: yes 
 
 One or more steps
 
-### Pickle.tags 
+#### Pickle.tags 
 
 * Type: [PickleTag](#pickletag)[] 
 * Required: yes 
@@ -1142,7 +1142,7 @@ One or more steps
 One or more tags. If this pickle is constructed from a Gherkin document,
 It includes inherited tags from the `Feature` as well.
 
-### Pickle.astNodeIds 
+#### Pickle.astNodeIds 
 
 * Type: string[] 
 * Required: yes 
@@ -1155,14 +1155,14 @@ id originating from the `Scenario` AST node, and the second from the `TableRow` 
 
 
 
-### PickleDocString.mediaType 
+#### PickleDocString.mediaType 
 
 * Type: string 
 * Required: no 
 
 
 
-### PickleDocString.content 
+#### PickleDocString.content 
 
 * Type: string 
 * Required: yes 
@@ -1173,14 +1173,14 @@ id originating from the `Scenario` AST node, and the second from the `TableRow` 
 
 An executable step
 
-### PickleStep.argument 
+#### PickleStep.argument 
 
 * Type: [PickleStepArgument](#picklestepargument) 
 * Required: no 
 
 
 
-### PickleStep.astNodeIds 
+#### PickleStep.astNodeIds 
 
 * Type: string[] 
 * Required: yes 
@@ -1188,14 +1188,14 @@ An executable step
 References the IDs of the source of the step. For Gherkin, this can be
 the ID of a Step, and possibly also the ID of a TableRow
 
-### PickleStep.id 
+#### PickleStep.id 
 
 * Type: string 
 * Required: yes 
 
 A unique ID for the PickleStep
 
-### PickleStep.type 
+#### PickleStep.type 
 
 * Type: [PickleStepType](#picklesteptype) 
 * Required: no 
@@ -1204,7 +1204,7 @@ The context in which the step was specified: context (Given), action (When) or o
 
 Note that the keywords `But` and `And` inherit their meaning from prior steps and the `*` 'keyword' doesn't have specific meaning (hence Unknown)
 
-### PickleStep.text 
+#### PickleStep.text 
 
 * Type: string 
 * Required: yes 
@@ -1215,14 +1215,14 @@ Note that the keywords `But` and `And` inherit their meaning from prior steps an
 
 An optional argument
 
-### PickleStepArgument.docString 
+#### PickleStepArgument.docString 
 
 * Type: [PickleDocString](#pickledocstring) 
 * Required: no 
 
 
 
-### PickleStepArgument.dataTable 
+#### PickleStepArgument.dataTable 
 
 * Type: [PickleTable](#pickletable) 
 * Required: no 
@@ -1233,7 +1233,7 @@ An optional argument
 
 
 
-### PickleTable.rows 
+#### PickleTable.rows 
 
 * Type: [PickleTableRow](#pickletablerow)[] 
 * Required: yes 
@@ -1244,7 +1244,7 @@ An optional argument
 
 
 
-### PickleTableCell.value 
+#### PickleTableCell.value 
 
 * Type: string 
 * Required: yes 
@@ -1255,7 +1255,7 @@ An optional argument
 
 
 
-### PickleTableRow.cells 
+#### PickleTableRow.cells 
 
 * Type: [PickleTableCell](#pickletablecell)[] 
 * Required: yes 
@@ -1266,14 +1266,14 @@ An optional argument
 
 A tag
 
-### PickleTag.name 
+#### PickleTag.name 
 
 * Type: string 
 * Required: yes 
 
 
 
-### PickleTag.astNodeId 
+#### PickleTag.astNodeId 
 
 * Type: string 
 * Required: yes 
@@ -1284,7 +1284,7 @@ Points to the AST node this was created from
 
 A source file, typically a Gherkin document or Java/Ruby/JavaScript source code
 
-### Source.uri 
+#### Source.uri 
 
 * Type: string 
 * Required: yes 
@@ -1292,14 +1292,14 @@ A source file, typically a Gherkin document or Java/Ruby/JavaScript source code
 The [URI](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier)
 of the source, typically a file path relative to the root directory
 
-### Source.data 
+#### Source.data 
 
 * Type: string 
 * Required: yes 
 
 The contents of the file
 
-### Source.mediaType 
+#### Source.mediaType 
 
 * Type: [SourceMediaType](#sourcemediatype) 
 * Required: yes 
@@ -1312,28 +1312,28 @@ text/x.cucumber.gherkin+plain
 Points to a [Source](#io.cucumber.messages.Source) identified by `uri` and a
 [Location](#io.cucumber.messages.Location) within that file.
 
-### SourceReference.uri 
+#### SourceReference.uri 
 
 * Type: string 
 * Required: no 
 
 
 
-### SourceReference.javaMethod 
+#### SourceReference.javaMethod 
 
 * Type: [JavaMethod](#javamethod) 
 * Required: no 
 
 
 
-### SourceReference.javaStackTraceElement 
+#### SourceReference.javaStackTraceElement 
 
 * Type: [JavaStackTraceElement](#javastacktraceelement) 
 * Required: no 
 
 
 
-### SourceReference.location 
+#### SourceReference.location 
 
 * Type: [Location](#location) 
 * Required: no 
@@ -1344,21 +1344,21 @@ Points to a [Source](#io.cucumber.messages.Source) identified by `uri` and a
 
 
 
-### JavaMethod.className 
+#### JavaMethod.className 
 
 * Type: string 
 * Required: yes 
 
 
 
-### JavaMethod.methodName 
+#### JavaMethod.methodName 
 
 * Type: string 
 * Required: yes 
 
 
 
-### JavaMethod.methodParameterTypes 
+#### JavaMethod.methodParameterTypes 
 
 * Type: string[] 
 * Required: yes 
@@ -1369,21 +1369,21 @@ Points to a [Source](#io.cucumber.messages.Source) identified by `uri` and a
 
 
 
-### JavaStackTraceElement.className 
+#### JavaStackTraceElement.className 
 
 * Type: string 
 * Required: yes 
 
 
 
-### JavaStackTraceElement.fileName 
+#### JavaStackTraceElement.fileName 
 
 * Type: string 
 * Required: yes 
 
 
 
-### JavaStackTraceElement.methodName 
+#### JavaStackTraceElement.methodName 
 
 * Type: string 
 * Required: yes 
@@ -1394,21 +1394,21 @@ Points to a [Source](#io.cucumber.messages.Source) identified by `uri` and a
 
 
 
-### StepDefinition.id 
+#### StepDefinition.id 
 
 * Type: string 
 * Required: yes 
 
 
 
-### StepDefinition.pattern 
+#### StepDefinition.pattern 
 
 * Type: [StepDefinitionPattern](#stepdefinitionpattern) 
 * Required: yes 
 
 
 
-### StepDefinition.sourceReference 
+#### StepDefinition.sourceReference 
 
 * Type: [SourceReference](#sourcereference) 
 * Required: yes 
@@ -1419,14 +1419,14 @@ Points to a [Source](#io.cucumber.messages.Source) identified by `uri` and a
 
 
 
-### StepDefinitionPattern.source 
+#### StepDefinitionPattern.source 
 
 * Type: string 
 * Required: yes 
 
 
 
-### StepDefinitionPattern.type 
+#### StepDefinitionPattern.type 
 
 * Type: [StepDefinitionPatternType](#stepdefinitionpatterntype) 
 * Required: yes 
@@ -1437,28 +1437,28 @@ Points to a [Source](#io.cucumber.messages.Source) identified by `uri` and a
 
 A `TestCase` contains a sequence of `TestStep`s.
 
-### TestCase.id 
+#### TestCase.id 
 
 * Type: string 
 * Required: yes 
 
 
 
-### TestCase.pickleId 
+#### TestCase.pickleId 
 
 * Type: string 
 * Required: yes 
 
 The ID of the `Pickle` this `TestCase` is derived from.
 
-### TestCase.testSteps 
+#### TestCase.testSteps 
 
 * Type: [TestStep](#teststep)[] 
 * Required: yes 
 
 
 
-### TestCase.testRunStartedId 
+#### TestCase.testRunStartedId 
 
 * Type: string 
 * Required: no 
@@ -1469,21 +1469,21 @@ Identifier for the test run that this test case belongs to
 
 
 
-### Group.children 
+#### Group.children 
 
 * Type: [Group](#group)[] 
 * Required: yes 
 
 
 
-### Group.start 
+#### Group.start 
 
 * Type: integer 
 * Required: no 
 
 
 
-### Group.value 
+#### Group.value 
 
 * Type: string 
 * Required: no 
@@ -1499,7 +1499,7 @@ This is used for the following purposes:
 
 This message closely matches the `Argument` class in the `cucumber-expressions` library.
 
-### StepMatchArgument.group 
+#### StepMatchArgument.group 
 
 * Type: [Group](#group) 
 * Required: yes 
@@ -1507,7 +1507,7 @@ This message closely matches the `Argument` class in the `cucumber-expressions` 
 Represents the outermost capture group of an argument. This message closely matches the
 `Group` class in the `cucumber-expressions` library.
 
-### StepMatchArgument.parameterTypeName 
+#### StepMatchArgument.parameterTypeName 
 
 * Type: string 
 * Required: no 
@@ -1518,7 +1518,7 @@ Represents the outermost capture group of an argument. This message closely matc
 
 
 
-### StepMatchArgumentsList.stepMatchArguments 
+#### StepMatchArgumentsList.stepMatchArguments 
 
 * Type: [StepMatchArgument](#stepmatchargument)[] 
 * Required: yes 
@@ -1530,28 +1530,28 @@ Represents the outermost capture group of an argument. This message closely matc
 A `TestStep` is derived from either a `PickleStep`
 combined with a `StepDefinition`, or from a `Hook`.
 
-### TestStep.hookId 
+#### TestStep.hookId 
 
 * Type: string 
 * Required: no 
 
 Pointer to the `Hook` (if derived from a Hook)
 
-### TestStep.id 
+#### TestStep.id 
 
 * Type: string 
 * Required: yes 
 
 
 
-### TestStep.pickleStepId 
+#### TestStep.pickleStepId 
 
 * Type: string 
 * Required: no 
 
 Pointer to the `PickleStep` (if derived from a `PickleStep`)
 
-### TestStep.stepDefinitionIds 
+#### TestStep.stepDefinitionIds 
 
 * Type: string[] 
 * Required: no 
@@ -1560,7 +1560,7 @@ Pointer to all the matching `StepDefinition`s (if derived from a `PickleStep`)
 Each element represents a matching step definition. A size of 0 means `UNDEFINED`,
 and a size of 2+ means `AMBIGUOUS`
 
-### TestStep.stepMatchArgumentsLists 
+#### TestStep.stepMatchArgumentsLists 
 
 * Type: [StepMatchArgumentsList](#stepmatchargumentslist)[] 
 * Required: no 
@@ -1571,21 +1571,21 @@ A list of list of StepMatchArgument (if derived from a `PickleStep`).
 
 
 
-### TestCaseFinished.testCaseStartedId 
+#### TestCaseFinished.testCaseStartedId 
 
 * Type: string 
 * Required: yes 
 
 
 
-### TestCaseFinished.timestamp 
+#### TestCaseFinished.timestamp 
 
 * Type: [Timestamp](#timestamp) 
 * Required: yes 
 
 
 
-### TestCaseFinished.willBeRetried 
+#### TestCaseFinished.willBeRetried 
 
 * Type: boolean 
 * Required: yes 
@@ -1596,7 +1596,7 @@ A list of list of StepMatchArgument (if derived from a `PickleStep`).
 
 
 
-### TestCaseStarted.attempt 
+#### TestCaseStarted.attempt 
 
 * Type: integer 
 * Required: yes 
@@ -1604,7 +1604,7 @@ A list of list of StepMatchArgument (if derived from a `PickleStep`).
 The first attempt should have value 0, and for each retry the value
 should increase by 1.
 
-### TestCaseStarted.id 
+#### TestCaseStarted.id 
 
 * Type: string 
 * Required: yes 
@@ -1612,21 +1612,21 @@ should increase by 1.
 Because a `TestCase` can be run multiple times (in case of a retry),
 we use this field to group messages relating to the same attempt.
 
-### TestCaseStarted.testCaseId 
+#### TestCaseStarted.testCaseId 
 
 * Type: string 
 * Required: yes 
 
 
 
-### TestCaseStarted.workerId 
+#### TestCaseStarted.workerId 
 
 * Type: string 
 * Required: no 
 
 An identifier for the worker process running this test case, if test cases are being run in parallel. The identifier will be unique per worker, but no particular format is defined - it could be an index, uuid, machine name etc - and as such should be assumed that it's not human readable.
 
-### TestCaseStarted.timestamp 
+#### TestCaseStarted.timestamp 
 
 * Type: [Timestamp](#timestamp) 
 * Required: yes 
@@ -1637,35 +1637,35 @@ An identifier for the worker process running this test case, if test cases are b
 
 
 
-### TestRunFinished.message 
+#### TestRunFinished.message 
 
 * Type: string 
 * Required: no 
 
 An informative message about the test run. Typically additional information about failure, but not necessarily.
 
-### TestRunFinished.success 
+#### TestRunFinished.success 
 
 * Type: boolean 
 * Required: yes 
 
 A test run is successful if all steps are either passed or skipped, all before/after hooks passed and no other exceptions where thrown.
 
-### TestRunFinished.timestamp 
+#### TestRunFinished.timestamp 
 
 * Type: [Timestamp](#timestamp) 
 * Required: yes 
 
 Timestamp when the TestRun is finished
 
-### TestRunFinished.exception 
+#### TestRunFinished.exception 
 
 * Type: [Exception](#exception) 
 * Required: no 
 
 Any exception thrown during the test run, if any. Does not include exceptions thrown while executing steps.
 
-### TestRunFinished.testRunStartedId 
+#### TestRunFinished.testRunStartedId 
 
 * Type: string 
 * Required: no 
@@ -1676,21 +1676,21 @@ Any exception thrown during the test run, if any. Does not include exceptions th
 
 
 
-### TestRunHookFinished.testRunHookStartedId 
+#### TestRunHookFinished.testRunHookStartedId 
 
 * Type: string 
 * Required: yes 
 
 Identifier for the hook execution that has finished
 
-### TestRunHookFinished.result 
+#### TestRunHookFinished.result 
 
 * Type: [TestStepResult](#teststepresult) 
 * Required: yes 
 
 
 
-### TestRunHookFinished.timestamp 
+#### TestRunHookFinished.timestamp 
 
 * Type: [Timestamp](#timestamp) 
 * Required: yes 
@@ -1701,28 +1701,28 @@ Identifier for the hook execution that has finished
 
 
 
-### TestRunHookStarted.id 
+#### TestRunHookStarted.id 
 
 * Type: string 
 * Required: yes 
 
 Unique identifier for this hook execution
 
-### TestRunHookStarted.testRunStartedId 
+#### TestRunHookStarted.testRunStartedId 
 
 * Type: string 
 * Required: yes 
 
 Identifier for the test run that this hook execution belongs to
 
-### TestRunHookStarted.hookId 
+#### TestRunHookStarted.hookId 
 
 * Type: string 
 * Required: yes 
 
 Identifier for the hook that will be executed
 
-### TestRunHookStarted.timestamp 
+#### TestRunHookStarted.timestamp 
 
 * Type: [Timestamp](#timestamp) 
 * Required: yes 
@@ -1733,14 +1733,14 @@ Identifier for the hook that will be executed
 
 
 
-### TestRunStarted.timestamp 
+#### TestRunStarted.timestamp 
 
 * Type: [Timestamp](#timestamp) 
 * Required: yes 
 
 
 
-### TestRunStarted.id 
+#### TestRunStarted.id 
 
 * Type: string 
 * Required: no 
@@ -1751,28 +1751,28 @@ Identifier for the hook that will be executed
 
 
 
-### TestStepFinished.testCaseStartedId 
+#### TestStepFinished.testCaseStartedId 
 
 * Type: string 
 * Required: yes 
 
 
 
-### TestStepFinished.testStepId 
+#### TestStepFinished.testStepId 
 
 * Type: string 
 * Required: yes 
 
 
 
-### TestStepFinished.testStepResult 
+#### TestStepFinished.testStepResult 
 
 * Type: [TestStepResult](#teststepresult) 
 * Required: yes 
 
 
 
-### TestStepFinished.timestamp 
+#### TestStepFinished.timestamp 
 
 * Type: [Timestamp](#timestamp) 
 * Required: yes 
@@ -1783,28 +1783,28 @@ Identifier for the hook that will be executed
 
 
 
-### TestStepResult.duration 
+#### TestStepResult.duration 
 
 * Type: [Duration](#duration) 
 * Required: yes 
 
 
 
-### TestStepResult.message 
+#### TestStepResult.message 
 
 * Type: string 
 * Required: no 
 
 An arbitrary bit of information that explains this result. If there was an exception, this should include a stringified representation of it including type, message and stack trace (the exact format will vary by platform).
 
-### TestStepResult.status 
+#### TestStepResult.status 
 
 * Type: [TestStepResultStatus](#teststepresultstatus) 
 * Required: yes 
 
 
 
-### TestStepResult.exception 
+#### TestStepResult.exception 
 
 * Type: [Exception](#exception) 
 * Required: no 
@@ -1815,21 +1815,21 @@ Exception thrown while executing this step, if any.
 
 
 
-### TestStepStarted.testCaseStartedId 
+#### TestStepStarted.testCaseStartedId 
 
 * Type: string 
 * Required: yes 
 
 
 
-### TestStepStarted.testStepId 
+#### TestStepStarted.testStepId 
 
 * Type: string 
 * Required: yes 
 
 
 
-### TestStepStarted.timestamp 
+#### TestStepStarted.timestamp 
 
 * Type: [Timestamp](#timestamp) 
 * Required: yes 
@@ -1840,7 +1840,7 @@ Exception thrown while executing this step, if any.
 
 
 
-### Timestamp.seconds 
+#### Timestamp.seconds 
 
 * Type: integer 
 * Required: yes 
@@ -1849,7 +1849,7 @@ Represents seconds of UTC time since Unix epoch
 1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
 9999-12-31T23:59:59Z inclusive.
 
-### Timestamp.nanos 
+#### Timestamp.nanos 
 
 * Type: integer 
 * Required: yes 
@@ -1863,14 +1863,14 @@ inclusive.
 
 
 
-### UndefinedParameterType.expression 
+#### UndefinedParameterType.expression 
 
 * Type: string 
 * Required: yes 
 
 
 
-### UndefinedParameterType.name 
+#### UndefinedParameterType.name 
 
 * Type: string 
 * Required: yes 


### PR DESCRIPTION
### 🤔 What's changed?

Use `message_name.property_name` for each property. This ensure the generated links are unambiguous.

### ⚡️ What's your motivation? 

Make it possible to deep link into a the message.md document.

### 🏷️ What kind of change is this?

- :book: Documentation (improvements without changing code)

