### PR TITLE
Generate entity relationship diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ from Cucumber. The protocol aims to decouple various components of the Cucumber 
 
 ![messages.png](jsonschema/messages.png)
 
-Note: Markdown and Excel formats are currently not supported and mentioned here as potential future alternative languages to express BDD scenarios.
+Notes:
+ * The image sketches out the general concept, but is incomplete. See [relations.md](jsonschema/relations.md) for a complete visualisation of the relationships between messages. 
+ * Markdown and Excel formats are currently not supported and mentioned here as potential future alternative languages to express BDD scenarios.
 
 ## JSON Schema
 

--- a/codegen/templates/relations.md.erb
+++ b/codegen/templates/relations.md.erb
@@ -1,0 +1,27 @@
+# Cucumber Messages
+
+
+```mermaid
+erDiagram
+<% @schemas.each do |key, schema| -%>
+<%- schema['properties'].each do |property_name, property| -%>
+<%-
+next unless property_name.end_with?("Id")
+referent = property_name.delete_suffix("Id")
+referent[0] = referent[0].upcase
+-%>
+
+<%= class_name(key) %> }|..|| <%= referent %>: <%= property_name %> 
+<%- end -%>
+<%- end -%>
+
+<% @schemas.each do |key, schema| -%>
+<%- schema['properties'].each do |property_name, property| -%>
+<%-
+  next unless property['$ref']    
+-%>
+
+<%= class_name(key) %> ||..|| <%= class_name(property['$ref']) %>: has 
+<%- end -%>
+<%- end -%>
+```

--- a/codegen/templates/relations.md.erb
+++ b/codegen/templates/relations.md.erb
@@ -2,7 +2,9 @@
 
 All relationships where an entity is referenced by `id`.
 
-Note: The left side cardinality of the relationship is always rendered as one-or-more, but may also be exactly-one. This can't be extracted from the json schema easily.
+Notes:
+ * The left side cardinality of the relationship is always rendered as one-or-more, but may also be exactly-one. This can't be extracted from the json schema easily.
+ * Worker is not actually an entity in the message protocol, but is referenced by id.
 
 ```mermaid
 ---

--- a/codegen/templates/relations.md.erb
+++ b/codegen/templates/relations.md.erb
@@ -6,7 +6,7 @@ Note: The left side cardinality of the relationship is always rendered as one-or
 
 ```mermaid
 ---
-title: Entity relationships  
+title: Entity relationships  - by id
 config:
     layout: elk
 ---
@@ -41,14 +41,20 @@ required = (schema['required'] || []).index(property_name)
 
 ```
 
-And all has-a relationships:
+And all has-a relationships, excluding `Envelope`:
 
 ```mermaid
+---
+title: Entity relationships - has a  
+config:
+    layout: elk
+---
 erDiagram
 <% @schemas.each do |key, schema| -%>
 <%- schema['properties'].each do |property_name, property| -%>
 <%-
   next unless property['$ref']    
+  next unless class_name(key) != "Envelope"    
 -%>
 
 <%= class_name(key) %> ||..|| <%= class_name(property['$ref']) %>: has a

--- a/codegen/templates/relations.md.erb
+++ b/codegen/templates/relations.md.erb
@@ -3,6 +3,7 @@
 
 ```mermaid
 erDiagram
+    direction TB
 <% @schemas.each do |key, schema| -%>
 <%- schema['properties'].each do |property_name, property| -%>
 <%-
@@ -14,6 +15,22 @@ referent[0] = referent[0].upcase
 <%= class_name(key) %> }|..|| <%= referent %>: <%= property_name %> 
 <%- end -%>
 <%- end -%>
+
+
+
+<% @schemas.each do |key, schema| -%>
+<%- schema['properties'].each do |property_name, property| -%>
+<%-
+next unless property_name.end_with?("Ids")
+referent = property_name.delete_suffix("Ids")
+referent[0] = referent[0].upcase
+-%>
+
+<%= class_name(key) %> }|..|{ <%= referent %>: <%= property_name %> 
+<%- end -%>
+<%- end -%>
+
+
 
 <% @schemas.each do |key, schema| -%>
 <%- schema['properties'].each do |property_name, property| -%>

--- a/codegen/templates/relations.md.erb
+++ b/codegen/templates/relations.md.erb
@@ -5,6 +5,7 @@ All relationships where an entity is referenced by `id`.
 Notes:
  * The left side cardinality of the relationship is always rendered as one-or-more, but may also be exactly-one. This can't be extracted from the json schema easily.
  * Worker is not actually an entity in the message protocol, but is referenced by id.
+ * `AstNode` is not actually an entity in the message protocol, but does reference an element in the `GherkinDocument`. 
 
 ```mermaid
 ---
@@ -13,34 +14,25 @@ config:
     layout: elk
 ---
 erDiagram
-<% @schemas.each do |key, schema| -%>
+<%- @schemas.each do |key, schema| -%>
 <%- schema['properties'].each do |property_name, property| -%>
-<%-
-next unless property_name.end_with?("Id")
-referent = property_name.delete_suffix("Id")
-referent[0] = referent[0].upcase
-required = (schema['required'] || []).index(property_name)
+<%- if property_name.end_with?("Id")
+      referent = property_name.delete_suffix("Id")
+      referent[0] = referent[0].upcase
+      required = (schema['required'] || []).index(property_name)
 -%>
-
-<%= class_name(key) %> }|..<%= required ? '||' : 'o|' %>  <%= referent %>: <%= property_name %> 
+<%= class_name(key) %> }|..<%= required ? '||' : 'o|' %>  <%= referent %>: <%= property_name %>
 <%- end -%>
-<%- end -%>
-
-
-
-<% @schemas.each do |key, schema| -%>
-<%- schema['properties'].each do |property_name, property| -%>
 <%-
-next unless property_name.end_with?("Ids")
-referent = property_name.delete_suffix("Ids")
-referent[0] = referent[0].upcase
-required = (schema['required'] || []).index(property_name)
+if property_name.end_with?("Ids")
+    referent = property_name.delete_suffix("Ids")
+    referent[0] = referent[0].upcase
+    required = (schema['required'] || []).index(property_name)
 -%>
-
-<%= class_name(key) %> }|..<%= required ? '|{' : 'o{' %>  <%= referent %>: <%= property_name %> 
+<%= class_name(key) %> }|..<%= required ? '|{' : 'o{' %>  <%= referent %>: <%= property_name %>
 <%- end -%>
 <%- end -%>
-
+<%- end -%>
 ```
 
 And all has-a relationships, excluding `Envelope`:
@@ -58,7 +50,6 @@ erDiagram
   next unless property['$ref']    
   next unless class_name(key) != "Envelope"    
 -%>
-
 <%= class_name(key) %> ||..|| <%= class_name(property['$ref']) %>: has a
 <%- end -%>
 <%- end -%>

--- a/codegen/templates/relations.md.erb
+++ b/codegen/templates/relations.md.erb
@@ -1,18 +1,26 @@
-# Cucumber Messages
+# Cucumber Messages  
 
+All relationships where an entity is referenced by `id`.
+
+Note: The left side cardinality of the relationship is always rendered as one-or-more, but may also be exactly-one. This can't be extracted from the json schema easily.
 
 ```mermaid
+---
+title: Entity relationships  
+config:
+    layout: elk
+---
 erDiagram
-    direction TB
 <% @schemas.each do |key, schema| -%>
 <%- schema['properties'].each do |property_name, property| -%>
 <%-
 next unless property_name.end_with?("Id")
 referent = property_name.delete_suffix("Id")
 referent[0] = referent[0].upcase
+required = (schema['required'] || []).index(property_name)
 -%>
 
-<%= class_name(key) %> }|..|| <%= referent %>: <%= property_name %> 
+<%= class_name(key) %> }|..<%= required ? '||' : 'o|' %>  <%= referent %>: <%= property_name %> 
 <%- end -%>
 <%- end -%>
 
@@ -24,21 +32,26 @@ referent[0] = referent[0].upcase
 next unless property_name.end_with?("Ids")
 referent = property_name.delete_suffix("Ids")
 referent[0] = referent[0].upcase
+required = (schema['required'] || []).index(property_name)
 -%>
 
-<%= class_name(key) %> }|..|{ <%= referent %>: <%= property_name %> 
+<%= class_name(key) %> }|..<%= required ? '|{' : 'o{' %>  <%= referent %>: <%= property_name %> 
 <%- end -%>
 <%- end -%>
 
+```
 
+And all has-a relationships:
 
+```mermaid
+erDiagram
 <% @schemas.each do |key, schema| -%>
 <%- schema['properties'].each do |property_name, property| -%>
 <%-
   next unless property['$ref']    
 -%>
 
-<%= class_name(key) %> ||..|| <%= class_name(property['$ref']) %>: has 
+<%= class_name(key) %> ||..|| <%= class_name(property['$ref']) %>: has a
 <%- end -%>
 <%- end -%>
 ```

--- a/jsonschema/Makefile
+++ b/jsonschema/Makefile
@@ -46,9 +46,8 @@ messages.md: $(schemas) ../codegen/codegen.rb ../codegen/templates/markdown.md.e
 	ruby ../codegen/codegen.rb Generator::Markdown markdown.md.erb > $@
 	ruby ../codegen/codegen.rb Generator::Markdown markdown.enum.md.erb >> $@
 
-relations.md: $(schemas) ../codegen/codegen.rb ../codegen/templates/relations.md.erb ../codegen/templates/relations.enum.md.erb
+relations.md: $(schemas) ../codegen/codegen.rb ../codegen/templates/relations.md.erb
 	ruby ../codegen/codegen.rb Generator::Markdown relations.md.erb > $@
-	ruby ../codegen/codegen.rb Generator::Markdown relations.enum.md.erb >> $@
 
 clean: ## Remove automatically generated documentation files and related artifacts
 	rm -f messages.md relations.md

--- a/jsonschema/Makefile
+++ b/jsonschema/Makefile
@@ -32,7 +32,7 @@ schemas = \
 help: ## Show this help
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make <target>\n\nWhere <target> is one of:\n"} /^[$$()% a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
-generate: require-doc messages.md ## Generate markdown documentation using the scripts in ./jsonschema/scripts for the generation
+generate: require-doc messages.md relations.md ## Generate markdown documentation using the scripts in ./jsonschema/scripts for the generation
 
 validate: $(schemas) ## Validate the json schemas are valid
 	npm install
@@ -46,5 +46,9 @@ messages.md: $(schemas) ../codegen/codegen.rb ../codegen/templates/markdown.md.e
 	ruby ../codegen/codegen.rb Generator::Markdown markdown.md.erb > $@
 	ruby ../codegen/codegen.rb Generator::Markdown markdown.enum.md.erb >> $@
 
+relations.md: $(schemas) ../codegen/codegen.rb ../codegen/templates/relations.md.erb ../codegen/templates/relations.enum.md.erb
+	ruby ../codegen/codegen.rb Generator::Markdown relations.md.erb > $@
+	ruby ../codegen/codegen.rb Generator::Markdown relations.enum.md.erb >> $@
+
 clean: ## Remove automatically generated documentation files and related artifacts
-	rm -f messages.md
+	rm -f messages.md relations.md

--- a/jsonschema/relations.md
+++ b/jsonschema/relations.md
@@ -5,6 +5,7 @@ All relationships where an entity is referenced by `id`.
 Notes:
  * The left side cardinality of the relationship is always rendered as one-or-more, but may also be exactly-one. This can't be extracted from the json schema easily.
  * Worker is not actually an entity in the message protocol, but is referenced by id.
+ * `AstNode` is not actually an entity in the message protocol, but does reference an element in the `GherkinDocument`. 
 
 ```mermaid
 ---
@@ -13,56 +14,29 @@ config:
     layout: elk
 ---
 erDiagram
-
-Attachment }|..o|  TestCaseStarted: testCaseStartedId 
-
-Attachment }|..o|  TestStep: testStepId 
-
-Attachment }|..o|  TestRunStarted: testRunStartedId 
-
-Attachment }|..o|  TestRunHookStarted: testRunHookStartedId 
-
-PickleTag }|..||  AstNode: astNodeId 
-
-TestCase }|..||  Pickle: pickleId 
-
-TestCase }|..o|  TestRunStarted: testRunStartedId 
-
-TestStep }|..o|  Hook: hookId 
-
-TestStep }|..o|  PickleStep: pickleStepId 
-
-TestCaseFinished }|..||  TestCaseStarted: testCaseStartedId 
-
-TestCaseStarted }|..||  TestCase: testCaseId 
-
-TestCaseStarted }|..o|  Worker: workerId 
-
-TestRunFinished }|..o|  TestRunStarted: testRunStartedId 
-
-TestRunHookFinished }|..||  TestRunHookStarted: testRunHookStartedId 
-
-TestRunHookStarted }|..||  TestRunStarted: testRunStartedId 
-
-TestRunHookStarted }|..||  Hook: hookId 
-
-TestStepFinished }|..||  TestCaseStarted: testCaseStartedId 
-
-TestStepFinished }|..||  TestStep: testStepId 
-
-TestStepStarted }|..||  TestCaseStarted: testCaseStartedId 
-
-TestStepStarted }|..||  TestStep: testStepId 
-
-
-
-
-Pickle }|..|{  AstNode: astNodeIds 
-
-PickleStep }|..|{  AstNode: astNodeIds 
-
-TestStep }|..o{  StepDefinition: stepDefinitionIds 
-
+Attachment }|..o|  TestCaseStarted: testCaseStartedId
+Attachment }|..o|  TestStep: testStepId
+Attachment }|..o|  TestRunStarted: testRunStartedId
+Attachment }|..o|  TestRunHookStarted: testRunHookStartedId
+Pickle }|..|{  AstNode: astNodeIds
+PickleStep }|..|{  AstNode: astNodeIds
+PickleTag }|..||  AstNode: astNodeId
+TestCase }|..||  Pickle: pickleId
+TestCase }|..o|  TestRunStarted: testRunStartedId
+TestStep }|..o|  Hook: hookId
+TestStep }|..o|  PickleStep: pickleStepId
+TestStep }|..o{  StepDefinition: stepDefinitionIds
+TestCaseFinished }|..||  TestCaseStarted: testCaseStartedId
+TestCaseStarted }|..||  TestCase: testCaseId
+TestCaseStarted }|..o|  Worker: workerId
+TestRunFinished }|..o|  TestRunStarted: testRunStartedId
+TestRunHookFinished }|..||  TestRunHookStarted: testRunHookStartedId
+TestRunHookStarted }|..||  TestRunStarted: testRunStartedId
+TestRunHookStarted }|..||  Hook: hookId
+TestStepFinished }|..||  TestCaseStarted: testCaseStartedId
+TestStepFinished }|..||  TestStep: testStepId
+TestStepStarted }|..||  TestCaseStarted: testCaseStartedId
+TestStepStarted }|..||  TestStep: testStepId
 ```
 
 And all has-a relationships, excluding `Envelope`:
@@ -74,112 +48,58 @@ config:
     layout: elk
 ---
 erDiagram
-
 Attachment ||..|| Source: has a
-
 Attachment ||..|| Timestamp: has a
-
 GherkinDocument ||..|| Feature: has a
-
 Background ||..|| Location: has a
-
 Comment ||..|| Location: has a
-
 DataTable ||..|| Location: has a
-
 DocString ||..|| Location: has a
-
 Examples ||..|| Location: has a
-
 Examples ||..|| TableRow: has a
-
 Feature ||..|| Location: has a
-
 FeatureChild ||..|| Rule: has a
-
 FeatureChild ||..|| Background: has a
-
 FeatureChild ||..|| Scenario: has a
-
 Rule ||..|| Location: has a
-
 RuleChild ||..|| Background: has a
-
 RuleChild ||..|| Scenario: has a
-
 Scenario ||..|| Location: has a
-
 Step ||..|| Location: has a
-
 Step ||..|| DocString: has a
-
 Step ||..|| DataTable: has a
-
 TableCell ||..|| Location: has a
-
 TableRow ||..|| Location: has a
-
 Tag ||..|| Location: has a
-
 Hook ||..|| SourceReference: has a
-
 Meta ||..|| Product: has a
-
 Meta ||..|| Product: has a
-
 Meta ||..|| Product: has a
-
 Meta ||..|| Product: has a
-
 Meta ||..|| Ci: has a
-
 Ci ||..|| Git: has a
-
 ParameterType ||..|| SourceReference: has a
-
 ParseError ||..|| SourceReference: has a
-
 PickleStep ||..|| PickleStepArgument: has a
-
 PickleStepArgument ||..|| PickleDocString: has a
-
 PickleStepArgument ||..|| PickleTable: has a
-
 SourceReference ||..|| JavaMethod: has a
-
 SourceReference ||..|| JavaStackTraceElement: has a
-
 SourceReference ||..|| Location: has a
-
 StepDefinition ||..|| StepDefinitionPattern: has a
-
 StepDefinition ||..|| SourceReference: has a
-
 StepMatchArgument ||..|| Group: has a
-
 TestCaseFinished ||..|| Timestamp: has a
-
 TestCaseStarted ||..|| Timestamp: has a
-
 TestRunFinished ||..|| Timestamp: has a
-
 TestRunFinished ||..|| Exception: has a
-
 TestRunHookFinished ||..|| TestStepResult: has a
-
 TestRunHookFinished ||..|| Timestamp: has a
-
 TestRunHookStarted ||..|| Timestamp: has a
-
 TestRunStarted ||..|| Timestamp: has a
-
 TestStepFinished ||..|| TestStepResult: has a
-
 TestStepFinished ||..|| Timestamp: has a
-
 TestStepResult ||..|| Duration: has a
-
 TestStepResult ||..|| Exception: has a
-
 TestStepStarted ||..|| Timestamp: has a
 ```

--- a/jsonschema/relations.md
+++ b/jsonschema/relations.md
@@ -11,6 +11,7 @@ config:
     layout: elk
 ---
 erDiagram
+group test
 
 Attachment }|..o|  TestCaseStarted: testCaseStartedId 
 

--- a/jsonschema/relations.md
+++ b/jsonschema/relations.md
@@ -6,7 +6,7 @@ Note: The left side cardinality of the relationship is always rendered as one-or
 
 ```mermaid
 ---
-title: Entity relationships  
+title: Entity relationships  - by id
 config:
     layout: elk
 ---
@@ -63,52 +63,19 @@ TestStep }|..o{  StepDefinition: stepDefinitionIds
 
 ```
 
-And all has-a relationships:
+And all has-a relationships, excluding `Envelope`:
 
 ```mermaid
+---
+title: Entity relationships - has a  
+config:
+    layout: elk
+---
 erDiagram
 
 Attachment ||..|| Source: has a
 
 Attachment ||..|| Timestamp: has a
-
-Envelope ||..|| Attachment: has a
-
-Envelope ||..|| GherkinDocument: has a
-
-Envelope ||..|| Hook: has a
-
-Envelope ||..|| Meta: has a
-
-Envelope ||..|| ParameterType: has a
-
-Envelope ||..|| ParseError: has a
-
-Envelope ||..|| Pickle: has a
-
-Envelope ||..|| Source: has a
-
-Envelope ||..|| StepDefinition: has a
-
-Envelope ||..|| TestCase: has a
-
-Envelope ||..|| TestCaseFinished: has a
-
-Envelope ||..|| TestCaseStarted: has a
-
-Envelope ||..|| TestRunFinished: has a
-
-Envelope ||..|| TestRunStarted: has a
-
-Envelope ||..|| TestStepFinished: has a
-
-Envelope ||..|| TestStepStarted: has a
-
-Envelope ||..|| TestRunHookStarted: has a
-
-Envelope ||..|| TestRunHookFinished: has a
-
-Envelope ||..|| UndefinedParameterType: has a
 
 GherkinDocument ||..|| Feature: has a
 

--- a/jsonschema/relations.md
+++ b/jsonschema/relations.md
@@ -2,7 +2,9 @@
 
 All relationships where an entity is referenced by `id`.
 
-Note: The left side cardinality of the relationship is always rendered as one-or-more, but may also be exactly-one. This can't be extracted from the json schema easily.
+Notes:
+ * The left side cardinality of the relationship is always rendered as one-or-more, but may also be exactly-one. This can't be extracted from the json schema easily.
+ * Worker is not actually an entity in the message protocol, but is referenced by id.
 
 ```mermaid
 ---

--- a/jsonschema/relations.md
+++ b/jsonschema/relations.md
@@ -11,7 +11,6 @@ config:
     layout: elk
 ---
 erDiagram
-group test
 
 Attachment }|..o|  TestCaseStarted: testCaseStartedId 
 

--- a/jsonschema/relations.md
+++ b/jsonschema/relations.md
@@ -1,205 +1,216 @@
-# Cucumber Messages
+# Cucumber Messages  
 
+All relationships where an entity is referenced by `id`.
+
+Note: The left side cardinality of the relationship is always rendered as one-or-more, but may also be exactly-one. This can't be extracted from the json schema easily.
+
+```mermaid
+---
+title: Entity relationships  
+config:
+    layout: elk
+---
+erDiagram
+
+Attachment }|..o|  TestCaseStarted: testCaseStartedId 
+
+Attachment }|..o|  TestStep: testStepId 
+
+Attachment }|..o|  TestRunStarted: testRunStartedId 
+
+Attachment }|..o|  TestRunHookStarted: testRunHookStartedId 
+
+PickleTag }|..||  AstNode: astNodeId 
+
+TestCase }|..||  Pickle: pickleId 
+
+TestCase }|..o|  TestRunStarted: testRunStartedId 
+
+TestStep }|..o|  Hook: hookId 
+
+TestStep }|..o|  PickleStep: pickleStepId 
+
+TestCaseFinished }|..||  TestCaseStarted: testCaseStartedId 
+
+TestCaseStarted }|..||  TestCase: testCaseId 
+
+TestCaseStarted }|..o|  Worker: workerId 
+
+TestRunFinished }|..o|  TestRunStarted: testRunStartedId 
+
+TestRunHookFinished }|..||  TestRunHookStarted: testRunHookStartedId 
+
+TestRunHookStarted }|..||  TestRunStarted: testRunStartedId 
+
+TestRunHookStarted }|..||  Hook: hookId 
+
+TestStepFinished }|..||  TestCaseStarted: testCaseStartedId 
+
+TestStepFinished }|..||  TestStep: testStepId 
+
+TestStepStarted }|..||  TestCaseStarted: testCaseStartedId 
+
+TestStepStarted }|..||  TestStep: testStepId 
+
+
+
+
+Pickle }|..|{  AstNode: astNodeIds 
+
+PickleStep }|..|{  AstNode: astNodeIds 
+
+TestStep }|..o{  StepDefinition: stepDefinitionIds 
+
+```
+
+And all has-a relationships:
 
 ```mermaid
 erDiagram
-    direction TB
 
-Attachment }|..|| TestCaseStarted: testCaseStartedId 
+Attachment ||..|| Source: has a
 
-Attachment }|..|| TestStep: testStepId 
+Attachment ||..|| Timestamp: has a
 
-Attachment }|..|| TestRunStarted: testRunStartedId 
+Envelope ||..|| Attachment: has a
 
-Attachment }|..|| TestRunHookStarted: testRunHookStartedId 
+Envelope ||..|| GherkinDocument: has a
 
-PickleTag }|..|| AstNode: astNodeId 
+Envelope ||..|| Hook: has a
 
-TestCase }|..|| Pickle: pickleId 
+Envelope ||..|| Meta: has a
 
-TestCase }|..|| TestRunStarted: testRunStartedId 
+Envelope ||..|| ParameterType: has a
 
-TestStep }|..|| Hook: hookId 
+Envelope ||..|| ParseError: has a
 
-TestStep }|..|| PickleStep: pickleStepId 
+Envelope ||..|| Pickle: has a
 
-TestCaseFinished }|..|| TestCaseStarted: testCaseStartedId 
+Envelope ||..|| Source: has a
 
-TestCaseStarted }|..|| TestCase: testCaseId 
+Envelope ||..|| StepDefinition: has a
 
-TestCaseStarted }|..|| Worker: workerId 
+Envelope ||..|| TestCase: has a
 
-TestRunFinished }|..|| TestRunStarted: testRunStartedId 
+Envelope ||..|| TestCaseFinished: has a
 
-TestRunHookFinished }|..|| TestRunHookStarted: testRunHookStartedId 
+Envelope ||..|| TestCaseStarted: has a
 
-TestRunHookStarted }|..|| TestRunStarted: testRunStartedId 
+Envelope ||..|| TestRunFinished: has a
 
-TestRunHookStarted }|..|| Hook: hookId 
+Envelope ||..|| TestRunStarted: has a
 
-TestStepFinished }|..|| TestCaseStarted: testCaseStartedId 
+Envelope ||..|| TestStepFinished: has a
 
-TestStepFinished }|..|| TestStep: testStepId 
+Envelope ||..|| TestStepStarted: has a
 
-TestStepStarted }|..|| TestCaseStarted: testCaseStartedId 
+Envelope ||..|| TestRunHookStarted: has a
 
-TestStepStarted }|..|| TestStep: testStepId 
+Envelope ||..|| TestRunHookFinished: has a
 
+Envelope ||..|| UndefinedParameterType: has a
 
+GherkinDocument ||..|| Feature: has a
 
+Background ||..|| Location: has a
 
-Pickle }|..|{ AstNode: astNodeIds 
+Comment ||..|| Location: has a
 
-PickleStep }|..|{ AstNode: astNodeIds 
+DataTable ||..|| Location: has a
 
-TestStep }|..|{ StepDefinition: stepDefinitionIds 
+DocString ||..|| Location: has a
 
+Examples ||..|| Location: has a
 
+Examples ||..|| TableRow: has a
 
+Feature ||..|| Location: has a
 
-Attachment ||..|| Source: has 
+FeatureChild ||..|| Rule: has a
 
-Attachment ||..|| Timestamp: has 
+FeatureChild ||..|| Background: has a
 
-Envelope ||..|| Attachment: has 
+FeatureChild ||..|| Scenario: has a
 
-Envelope ||..|| GherkinDocument: has 
+Rule ||..|| Location: has a
 
-Envelope ||..|| Hook: has 
+RuleChild ||..|| Background: has a
 
-Envelope ||..|| Meta: has 
+RuleChild ||..|| Scenario: has a
 
-Envelope ||..|| ParameterType: has 
+Scenario ||..|| Location: has a
 
-Envelope ||..|| ParseError: has 
+Step ||..|| Location: has a
 
-Envelope ||..|| Pickle: has 
+Step ||..|| DocString: has a
 
-Envelope ||..|| Source: has 
+Step ||..|| DataTable: has a
 
-Envelope ||..|| StepDefinition: has 
+TableCell ||..|| Location: has a
 
-Envelope ||..|| TestCase: has 
+TableRow ||..|| Location: has a
 
-Envelope ||..|| TestCaseFinished: has 
+Tag ||..|| Location: has a
 
-Envelope ||..|| TestCaseStarted: has 
+Hook ||..|| SourceReference: has a
 
-Envelope ||..|| TestRunFinished: has 
+Meta ||..|| Product: has a
 
-Envelope ||..|| TestRunStarted: has 
+Meta ||..|| Product: has a
 
-Envelope ||..|| TestStepFinished: has 
+Meta ||..|| Product: has a
 
-Envelope ||..|| TestStepStarted: has 
+Meta ||..|| Product: has a
 
-Envelope ||..|| TestRunHookStarted: has 
+Meta ||..|| Ci: has a
 
-Envelope ||..|| TestRunHookFinished: has 
+Ci ||..|| Git: has a
 
-Envelope ||..|| UndefinedParameterType: has 
+ParameterType ||..|| SourceReference: has a
 
-GherkinDocument ||..|| Feature: has 
+ParseError ||..|| SourceReference: has a
 
-Background ||..|| Location: has 
+PickleStep ||..|| PickleStepArgument: has a
 
-Comment ||..|| Location: has 
+PickleStepArgument ||..|| PickleDocString: has a
 
-DataTable ||..|| Location: has 
+PickleStepArgument ||..|| PickleTable: has a
 
-DocString ||..|| Location: has 
+SourceReference ||..|| JavaMethod: has a
 
-Examples ||..|| Location: has 
+SourceReference ||..|| JavaStackTraceElement: has a
 
-Examples ||..|| TableRow: has 
+SourceReference ||..|| Location: has a
 
-Feature ||..|| Location: has 
+StepDefinition ||..|| StepDefinitionPattern: has a
 
-FeatureChild ||..|| Rule: has 
+StepDefinition ||..|| SourceReference: has a
 
-FeatureChild ||..|| Background: has 
+StepMatchArgument ||..|| Group: has a
 
-FeatureChild ||..|| Scenario: has 
+TestCaseFinished ||..|| Timestamp: has a
 
-Rule ||..|| Location: has 
+TestCaseStarted ||..|| Timestamp: has a
 
-RuleChild ||..|| Background: has 
+TestRunFinished ||..|| Timestamp: has a
 
-RuleChild ||..|| Scenario: has 
+TestRunFinished ||..|| Exception: has a
 
-Scenario ||..|| Location: has 
+TestRunHookFinished ||..|| TestStepResult: has a
 
-Step ||..|| Location: has 
+TestRunHookFinished ||..|| Timestamp: has a
 
-Step ||..|| DocString: has 
+TestRunHookStarted ||..|| Timestamp: has a
 
-Step ||..|| DataTable: has 
+TestRunStarted ||..|| Timestamp: has a
 
-TableCell ||..|| Location: has 
+TestStepFinished ||..|| TestStepResult: has a
 
-TableRow ||..|| Location: has 
+TestStepFinished ||..|| Timestamp: has a
 
-Tag ||..|| Location: has 
+TestStepResult ||..|| Duration: has a
 
-Hook ||..|| SourceReference: has 
+TestStepResult ||..|| Exception: has a
 
-Meta ||..|| Product: has 
-
-Meta ||..|| Product: has 
-
-Meta ||..|| Product: has 
-
-Meta ||..|| Product: has 
-
-Meta ||..|| Ci: has 
-
-Ci ||..|| Git: has 
-
-ParameterType ||..|| SourceReference: has 
-
-ParseError ||..|| SourceReference: has 
-
-PickleStep ||..|| PickleStepArgument: has 
-
-PickleStepArgument ||..|| PickleDocString: has 
-
-PickleStepArgument ||..|| PickleTable: has 
-
-SourceReference ||..|| JavaMethod: has 
-
-SourceReference ||..|| JavaStackTraceElement: has 
-
-SourceReference ||..|| Location: has 
-
-StepDefinition ||..|| StepDefinitionPattern: has 
-
-StepDefinition ||..|| SourceReference: has 
-
-StepMatchArgument ||..|| Group: has 
-
-TestCaseFinished ||..|| Timestamp: has 
-
-TestCaseStarted ||..|| Timestamp: has 
-
-TestRunFinished ||..|| Timestamp: has 
-
-TestRunFinished ||..|| Exception: has 
-
-TestRunHookFinished ||..|| TestStepResult: has 
-
-TestRunHookFinished ||..|| Timestamp: has 
-
-TestRunHookStarted ||..|| Timestamp: has 
-
-TestRunStarted ||..|| Timestamp: has 
-
-TestStepFinished ||..|| TestStepResult: has 
-
-TestStepFinished ||..|| Timestamp: has 
-
-TestStepResult ||..|| Duration: has 
-
-TestStepResult ||..|| Exception: has 
-
-TestStepStarted ||..|| Timestamp: has 
+TestStepStarted ||..|| Timestamp: has a
 ```

--- a/jsonschema/relations.md
+++ b/jsonschema/relations.md
@@ -3,6 +3,7 @@
 
 ```mermaid
 erDiagram
+    direction TB
 
 Attachment }|..|| TestCaseStarted: testCaseStartedId 
 
@@ -43,6 +44,17 @@ TestStepFinished }|..|| TestStep: testStepId
 TestStepStarted }|..|| TestCaseStarted: testCaseStartedId 
 
 TestStepStarted }|..|| TestStep: testStepId 
+
+
+
+
+Pickle }|..|{ AstNode: astNodeIds 
+
+PickleStep }|..|{ AstNode: astNodeIds 
+
+TestStep }|..|{ StepDefinition: stepDefinitionIds 
+
+
 
 
 Attachment ||..|| Source: has 

--- a/jsonschema/relations.md
+++ b/jsonschema/relations.md
@@ -1,0 +1,193 @@
+# Cucumber Messages
+
+
+```mermaid
+erDiagram
+
+Attachment }|..|| TestCaseStarted: testCaseStartedId 
+
+Attachment }|..|| TestStep: testStepId 
+
+Attachment }|..|| TestRunStarted: testRunStartedId 
+
+Attachment }|..|| TestRunHookStarted: testRunHookStartedId 
+
+PickleTag }|..|| AstNode: astNodeId 
+
+TestCase }|..|| Pickle: pickleId 
+
+TestCase }|..|| TestRunStarted: testRunStartedId 
+
+TestStep }|..|| Hook: hookId 
+
+TestStep }|..|| PickleStep: pickleStepId 
+
+TestCaseFinished }|..|| TestCaseStarted: testCaseStartedId 
+
+TestCaseStarted }|..|| TestCase: testCaseId 
+
+TestCaseStarted }|..|| Worker: workerId 
+
+TestRunFinished }|..|| TestRunStarted: testRunStartedId 
+
+TestRunHookFinished }|..|| TestRunHookStarted: testRunHookStartedId 
+
+TestRunHookStarted }|..|| TestRunStarted: testRunStartedId 
+
+TestRunHookStarted }|..|| Hook: hookId 
+
+TestStepFinished }|..|| TestCaseStarted: testCaseStartedId 
+
+TestStepFinished }|..|| TestStep: testStepId 
+
+TestStepStarted }|..|| TestCaseStarted: testCaseStartedId 
+
+TestStepStarted }|..|| TestStep: testStepId 
+
+
+Attachment ||..|| Source: has 
+
+Attachment ||..|| Timestamp: has 
+
+Envelope ||..|| Attachment: has 
+
+Envelope ||..|| GherkinDocument: has 
+
+Envelope ||..|| Hook: has 
+
+Envelope ||..|| Meta: has 
+
+Envelope ||..|| ParameterType: has 
+
+Envelope ||..|| ParseError: has 
+
+Envelope ||..|| Pickle: has 
+
+Envelope ||..|| Source: has 
+
+Envelope ||..|| StepDefinition: has 
+
+Envelope ||..|| TestCase: has 
+
+Envelope ||..|| TestCaseFinished: has 
+
+Envelope ||..|| TestCaseStarted: has 
+
+Envelope ||..|| TestRunFinished: has 
+
+Envelope ||..|| TestRunStarted: has 
+
+Envelope ||..|| TestStepFinished: has 
+
+Envelope ||..|| TestStepStarted: has 
+
+Envelope ||..|| TestRunHookStarted: has 
+
+Envelope ||..|| TestRunHookFinished: has 
+
+Envelope ||..|| UndefinedParameterType: has 
+
+GherkinDocument ||..|| Feature: has 
+
+Background ||..|| Location: has 
+
+Comment ||..|| Location: has 
+
+DataTable ||..|| Location: has 
+
+DocString ||..|| Location: has 
+
+Examples ||..|| Location: has 
+
+Examples ||..|| TableRow: has 
+
+Feature ||..|| Location: has 
+
+FeatureChild ||..|| Rule: has 
+
+FeatureChild ||..|| Background: has 
+
+FeatureChild ||..|| Scenario: has 
+
+Rule ||..|| Location: has 
+
+RuleChild ||..|| Background: has 
+
+RuleChild ||..|| Scenario: has 
+
+Scenario ||..|| Location: has 
+
+Step ||..|| Location: has 
+
+Step ||..|| DocString: has 
+
+Step ||..|| DataTable: has 
+
+TableCell ||..|| Location: has 
+
+TableRow ||..|| Location: has 
+
+Tag ||..|| Location: has 
+
+Hook ||..|| SourceReference: has 
+
+Meta ||..|| Product: has 
+
+Meta ||..|| Product: has 
+
+Meta ||..|| Product: has 
+
+Meta ||..|| Product: has 
+
+Meta ||..|| Ci: has 
+
+Ci ||..|| Git: has 
+
+ParameterType ||..|| SourceReference: has 
+
+ParseError ||..|| SourceReference: has 
+
+PickleStep ||..|| PickleStepArgument: has 
+
+PickleStepArgument ||..|| PickleDocString: has 
+
+PickleStepArgument ||..|| PickleTable: has 
+
+SourceReference ||..|| JavaMethod: has 
+
+SourceReference ||..|| JavaStackTraceElement: has 
+
+SourceReference ||..|| Location: has 
+
+StepDefinition ||..|| StepDefinitionPattern: has 
+
+StepDefinition ||..|| SourceReference: has 
+
+StepMatchArgument ||..|| Group: has 
+
+TestCaseFinished ||..|| Timestamp: has 
+
+TestCaseStarted ||..|| Timestamp: has 
+
+TestRunFinished ||..|| Timestamp: has 
+
+TestRunFinished ||..|| Exception: has 
+
+TestRunHookFinished ||..|| TestStepResult: has 
+
+TestRunHookFinished ||..|| Timestamp: has 
+
+TestRunHookStarted ||..|| Timestamp: has 
+
+TestRunStarted ||..|| Timestamp: has 
+
+TestStepFinished ||..|| TestStepResult: has 
+
+TestStepFinished ||..|| Timestamp: has 
+
+TestStepResult ||..|| Duration: has 
+
+TestStepResult ||..|| Exception: has 
+
+TestStepStarted ||..|| Timestamp: has 
+```


### PR DESCRIPTION
### 🤔 What's changed?

Added a generated mermaid diagram to visualize the entity relationships of messages.

<img width="1012" height="368" alt="image" src="https://github.com/user-attachments/assets/22393292-4b8b-4dcf-a886-26b0a3ca33e2" />


### ⚡️ What's your motivation? 

This should help when working on Cucumber  Query to ensure we have a complete set of methods to operate on all relationships.

Closes: https://github.com/cucumber/messages/issues/212

### 🏷️ What kind of change is this?

- :book: Documentation (improvements without changing code)


### 📋 Checklist:


- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
