### PR TITLE
Add workerId to TestRunHookStarted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Add `workerId` to `TestRunHookStarted` ([#332](https://github.com/cucumber/messages/pull/332))
+
 ### Changed
 - Update documentation for `TestStepResult.message` ([#315](https://github.com/cucumber/messages/pull/315))
 - [JavaScript] Drop dependency on `uuid` package ([#289](https://github.com/cucumber/messages/pull/289)

--- a/cpp/include/messages/cucumber/messages/test_run_hook_started.hpp
+++ b/cpp/include/messages/cucumber/messages/test_run_hook_started.hpp
@@ -23,6 +23,7 @@ struct test_run_hook_started
     std::string id;
     std::string test_run_started_id;
     std::string hook_id;
+    std::optional<std::string> worker_id;
     cucumber::messages::timestamp timestamp;
 
     std::string to_string() const;

--- a/cpp/src/lib/messages/cucumber/messages/test_run_hook_started.cpp
+++ b/cpp/src/lib/messages/cucumber/messages/test_run_hook_started.cpp
@@ -13,6 +13,7 @@ test_run_hook_started::to_string() const
     cucumber::messages::to_string(oss, "id=", id);
     cucumber::messages::to_string(oss, ", test_run_started_id=", test_run_started_id);
     cucumber::messages::to_string(oss, ", hook_id=", hook_id);
+    cucumber::messages::to_string(oss, ", worker_id=", worker_id);
     cucumber::messages::to_string(oss, ", timestamp=", timestamp);
 
     return oss.str();
@@ -24,6 +25,7 @@ test_run_hook_started::to_json(json& j) const
     cucumber::messages::to_json(j, camelize("id"), id);
     cucumber::messages::to_json(j, camelize("test_run_started_id"), test_run_started_id);
     cucumber::messages::to_json(j, camelize("hook_id"), hook_id);
+    cucumber::messages::to_json(j, camelize("worker_id"), worker_id);
     cucumber::messages::to_json(j, camelize("timestamp"), timestamp);
 }
 

--- a/dotnet/Cucumber.Messages/generated/TestRunHookStarted.cs
+++ b/dotnet/Cucumber.Messages/generated/TestRunHookStarted.cs
@@ -28,6 +28,10 @@ public sealed class TestRunHookStarted
      * Identifier for the hook that will be executed
      */
     public string HookId { get; private set; }
+    /**
+     * An identifier for the worker process running this hook, if parallel workers are in use. The identifier will be unique per worker, but no particular format is defined - it could be an index, uuid, machine name etc - and as such should be assumed that it's not human readable.
+     */
+    public string WorkerId { get; private set; }
     public Timestamp Timestamp { get; private set; }
 
 
@@ -35,6 +39,7 @@ public sealed class TestRunHookStarted
         string id,
         string testRunStartedId,
         string hookId,
+        string workerId,
         Timestamp timestamp
     ) 
     {
@@ -44,6 +49,7 @@ public sealed class TestRunHookStarted
         this.TestRunStartedId = testRunStartedId;
         RequireNonNull<string>(hookId, "HookId", "TestRunHookStarted.HookId cannot be null");
         this.HookId = hookId;
+        this.WorkerId = workerId;
         RequireNonNull<Timestamp>(timestamp, "Timestamp", "TestRunHookStarted.Timestamp cannot be null");
         this.Timestamp = timestamp;
     }
@@ -57,6 +63,7 @@ public sealed class TestRunHookStarted
             Id.Equals(that.Id) &&         
             TestRunStartedId.Equals(that.TestRunStartedId) &&         
             HookId.Equals(that.HookId) &&         
+            Object.Equals(WorkerId, that.WorkerId) &&         
             Timestamp.Equals(that.Timestamp);        
     }
 
@@ -69,6 +76,8 @@ public sealed class TestRunHookStarted
           hash = hash * 31 + TestRunStartedId.GetHashCode();
         if (HookId != null)
           hash = hash * 31 + HookId.GetHashCode();
+        if (WorkerId != null)
+          hash = hash * 31 + WorkerId.GetHashCode();
         if (Timestamp != null)
           hash = hash * 31 + Timestamp.GetHashCode();
         return hash;
@@ -80,6 +89,7 @@ public sealed class TestRunHookStarted
             "id=" + Id +
             ", testRunStartedId=" + TestRunStartedId +
             ", hookId=" + HookId +
+            ", workerId=" + WorkerId +
             ", timestamp=" + Timestamp +
             '}';
     }

--- a/go/messages.go
+++ b/go/messages.go
@@ -357,6 +357,7 @@ type TestRunHookStarted struct {
 	Id               string     `json:"id"`
 	TestRunStartedId string     `json:"testRunStartedId"`
 	HookId           string     `json:"hookId"`
+	WorkerId         string     `json:"workerId,omitempty"`
 	Timestamp        *Timestamp `json:"timestamp"`
 }
 

--- a/java/src/generated/java/io/cucumber/messages/types/TestRunHookStarted.java
+++ b/java/src/generated/java/io/cucumber/messages/types/TestRunHookStarted.java
@@ -16,17 +16,20 @@ public final class TestRunHookStarted {
     private final String id;
     private final String testRunStartedId;
     private final String hookId;
+    private final String workerId;
     private final Timestamp timestamp;
 
     public TestRunHookStarted(
         String id,
         String testRunStartedId,
         String hookId,
+        String workerId,
         Timestamp timestamp
     ) {
         this.id = requireNonNull(id, "TestRunHookStarted.id cannot be null");
         this.testRunStartedId = requireNonNull(testRunStartedId, "TestRunHookStarted.testRunStartedId cannot be null");
         this.hookId = requireNonNull(hookId, "TestRunHookStarted.hookId cannot be null");
+        this.workerId = workerId;
         this.timestamp = requireNonNull(timestamp, "TestRunHookStarted.timestamp cannot be null");
     }
 
@@ -51,6 +54,13 @@ public final class TestRunHookStarted {
         return hookId;
     }
 
+    /**
+      * An identifier for the worker process running this hook, if parallel workers are in use. The identifier will be unique per worker, but no particular format is defined - it could be an index, uuid, machine name etc - and as such should be assumed that it's not human readable.
+     */
+    public Optional<String> getWorkerId() {
+        return Optional.ofNullable(workerId);
+    }
+
     public Timestamp getTimestamp() {
         return timestamp;
     }
@@ -64,6 +74,7 @@ public final class TestRunHookStarted {
             id.equals(that.id) &&         
             testRunStartedId.equals(that.testRunStartedId) &&         
             hookId.equals(that.hookId) &&         
+            Objects.equals(workerId, that.workerId) &&         
             timestamp.equals(that.timestamp);        
     }
 
@@ -73,6 +84,7 @@ public final class TestRunHookStarted {
             id,
             testRunStartedId,
             hookId,
+            workerId,
             timestamp
         );
     }
@@ -83,6 +95,7 @@ public final class TestRunHookStarted {
             "id=" + id +
             ", testRunStartedId=" + testRunStartedId +
             ", hookId=" + hookId +
+            ", workerId=" + workerId +
             ", timestamp=" + timestamp +
             '}';
     }

--- a/javascript/src/messages.ts
+++ b/javascript/src/messages.ts
@@ -652,6 +652,8 @@ export class TestRunHookStarted {
 
   hookId: string = ''
 
+  workerId?: string
+
   @Type(() => Timestamp)
   timestamp: Timestamp = new Timestamp()
 }

--- a/jsonschema/messages.md
+++ b/jsonschema/messages.md
@@ -1722,6 +1722,13 @@ Identifier for the test run that this hook execution belongs to
 
 Identifier for the hook that will be executed
 
+#### TestRunHookStarted.workerId 
+
+* Type: string 
+* Required: no 
+
+An identifier for the worker process running this hook, if parallel workers are in use. The identifier will be unique per worker, but no particular format is defined - it could be an index, uuid, machine name etc - and as such should be assumed that it's not human readable.
+
 #### TestRunHookStarted.timestamp 
 
 * Type: [Timestamp](#timestamp) 

--- a/jsonschema/relations.md
+++ b/jsonschema/relations.md
@@ -33,6 +33,7 @@ TestRunFinished }|..o| TestRunStarted: testRunStartedId
 TestRunHookFinished }|..|| TestRunHookStarted: testRunHookStartedId
 TestRunHookStarted }|..|| TestRunStarted: testRunStartedId
 TestRunHookStarted }|..|| Hook: hookId
+TestRunHookStarted }|..o| Worker: workerId
 TestStepFinished }|..|| TestCaseStarted: testCaseStartedId
 TestStepFinished }|..|| TestStep: testStepId
 TestStepStarted }|..|| TestCaseStarted: testCaseStartedId

--- a/jsonschema/src/TestRunHookStarted.json
+++ b/jsonschema/src/TestRunHookStarted.json
@@ -21,6 +21,10 @@
       "description": "Identifier for the hook that will be executed",
       "type": "string"
     },
+    "workerId": {
+      "description": "An identifier for the worker process running this hook, if parallel workers are in use. The identifier will be unique per worker, but no particular format is defined - it could be an index, uuid, machine name etc - and as such should be assumed that it's not human readable.",
+      "type": "string"
+    },
     "timestamp": {
       "$ref": "./Timestamp.json"
     }

--- a/perl/lib/Cucumber/Messages.pm
+++ b/perl/lib/Cucumber/Messages.pm
@@ -4413,6 +4413,7 @@ my %types = (
    id => 'string',
    test_run_started_id => 'string',
    hook_id => 'string',
+   worker_id => 'string',
    timestamp => 'Cucumber::Messages::Timestamp',
 );
 
@@ -4457,6 +4458,16 @@ has hook_id =>
     (is => 'ro',
      required => 1,
      default => sub { '' },
+    );
+
+
+=head4 worker_id
+
+An identifier for the worker process running this hook, if parallel workers are in use. The identifier will be unique per worker, but no particular format is defined - it could be an index, uuid, machine name etc - and as such should be assumed that it's not human readable.
+=cut
+
+has worker_id =>
+    (is => 'ro',
     );
 
 

--- a/php/src-generated/TestRunHookStarted.php
+++ b/php/src-generated/TestRunHookStarted.php
@@ -40,6 +40,11 @@ final class TestRunHookStarted implements JsonSerializable
          * Identifier for the hook that will be executed
          */
         public readonly string $hookId = '',
+
+        /**
+         * An identifier for the worker process running this hook, if parallel workers are in use. The identifier will be unique per worker, but no particular format is defined - it could be an index, uuid, machine name etc - and as such should be assumed that it's not human readable.
+         */
+        public readonly ?string $workerId = null,
         public readonly Timestamp $timestamp = new Timestamp(),
     ) {
     }
@@ -54,12 +59,14 @@ final class TestRunHookStarted implements JsonSerializable
         self::ensureId($arr);
         self::ensureTestRunStartedId($arr);
         self::ensureHookId($arr);
+        self::ensureWorkerId($arr);
         self::ensureTimestamp($arr);
 
         return new self(
             (string) $arr['id'],
             (string) $arr['testRunStartedId'],
             (string) $arr['hookId'],
+            isset($arr['workerId']) ? (string) $arr['workerId'] : null,
             Timestamp::fromArray($arr['timestamp']),
         );
     }
@@ -100,6 +107,16 @@ final class TestRunHookStarted implements JsonSerializable
         }
         if (array_key_exists('hookId', $arr) && is_array($arr['hookId'])) {
             throw new SchemaViolationException('Property \'hookId\' was array');
+        }
+    }
+
+    /**
+     * @psalm-assert array{workerId?: string|int|bool} $arr
+     */
+    private static function ensureWorkerId(array $arr): void
+    {
+        if (array_key_exists('workerId', $arr) && is_array($arr['workerId'])) {
+            throw new SchemaViolationException('Property \'workerId\' was array');
         }
     }
 

--- a/python/src/cucumber_messages/_messages.py
+++ b/python/src/cucumber_messages/_messages.py
@@ -629,6 +629,7 @@ class TestRunHookStarted:
     id: str  # Unique identifier for this hook execution
     test_run_started_id: str  # Identifier for the test run that this hook execution belongs to
     timestamp: Timestamp
+    worker_id: Optional[str] = None  # An identifier for the worker process running this hook, if parallel workers are in use. The identifier will be unique per worker, but no particular format is defined - it could be an index, uuid, machine name etc - and as such should be assumed that it's not human readable.
 
 
 @dataclass

--- a/ruby/lib/cucumber/messages/test_run_hook_started.rb
+++ b/ruby/lib/cucumber/messages/test_run_hook_started.rb
@@ -23,17 +23,24 @@ module Cucumber
       ##
       attr_reader :hook_id
 
+      ##
+      # An identifier for the worker process running this hook, if parallel workers are in use. The identifier will be unique per worker, but no particular format is defined - it could be an index, uuid, machine name etc - and as such should be assumed that it's not human readable.
+      ##
+      attr_reader :worker_id
+
       attr_reader :timestamp
 
       def initialize(
         id: '',
         test_run_started_id: '',
         hook_id: '',
+        worker_id: nil,
         timestamp: Timestamp.new
       )
         @id = id
         @test_run_started_id = test_run_started_id
         @hook_id = hook_id
+        @worker_id = worker_id
         @timestamp = timestamp
         super()
       end
@@ -52,6 +59,7 @@ module Cucumber
           id: hash[:id],
           test_run_started_id: hash[:testRunStartedId],
           hook_id: hash[:hookId],
+          worker_id: hash[:workerId],
           timestamp: Timestamp.from_h(hash[:timestamp])
         )
       end


### PR DESCRIPTION
### 🤔 What's changed?

This PR adds an optional `workerId` property on the new-ish `TestRunHookStarted` message.

This mirrors what we already have on `TestCaseStarted` and will be needed to provide useful feedback via formatters where e.g. a BeforeAll hook is running on 5 workers but errors on 1 of them.

### ⚡️ What's your motivation? 

Part of https://github.com/cucumber/common/issues/2273

### 🏷️ What kind of change is this?

- :zap: New feature (non-breaking change which adds new behaviour)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
