### PR TITLE
fix: Redundant Python test workflow run on pre-commit changes

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -15,7 +15,6 @@ on:
     branches:
       - main
     paths:
-      - .pre-commit-config.yaml
       - python/**
       - Makefile
       - .github/**


### PR DESCRIPTION
Should run whenever there is a push to a Renovate branch. Doesn't require an additional run on same code if is also on a pull request.

### 🤔 What's changed?

Remove Python test workflow run on pre-commit pull request changes.

### ⚡️ What's your motivation? 

Avoid redundant duplicate Python test workflow runs on renovate changes to pre-commit configuration (see #336).

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

- NA

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)