### PR TITLE
Precommit dependency tags over hashes for Renovate compatibility

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,3 +25,10 @@ repos:
     rev: v1.18.1
     hooks:
       - id: mypy
+  - repo: https://github.com/astral-sh/uv-pre-commit
+    rev: 0.8.17
+    hooks:
+      # Ensure the uv lock file is up to date
+      - id: uv-lock
+        files: python/pyproject.toml
+        args: [--project, python]

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.9"
 
 [[package]]
@@ -126,7 +126,7 @@ wheels = [
 
 [[package]]
 name = "cucumber-messages"
-version = "28.1.0"
+version = "29.0.1"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
### 🤔 What's changed?

- Use tags for pre-commit dependencies instead of frozen hashes of the same.
- Pre-commit hook to link the uv lock file is up to date.

### ⚡️ What's your motivation? 

- Renovate uses tags. Hashes will be overwritten and cause issues for Renovate in determining the version in use. Ultimately it will update, though leave automated commented references to the previous pinned tags - which is undesirable. Tradeoff to enable automatic dependency updates.
- Automatically validate the lock file is up to date or whether otherwise requires updates.

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

- NA.

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)