### PR TITLE
java: Add OSGi metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- [Java] Add OSGi metadata ([#344](https://github.com/cucumber/messages/pull/344))
 
 ## [30.0.0] - 2025-10-03
 ### Changed
@@ -13,9 +15,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Removed
 - [Python] Dropped legacy .egg-info metadata distribution artifacts ([#324](https://github.com/cucumber/messages/pull/324))
-
-### Added
-- [Java] Add OSGi metadata ([#344](https://github.com/cucumber/messages/pull/344))
 
 ## [29.0.1] - 2025-09-08
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 - [Python] Dropped legacy .egg-info metadata distribution artifacts ([#324](https://github.com/cucumber/messages/pull/324))
 
+### Added
+- [Java] Add OSGi metadata ([#344](https://github.com/cucumber/messages/pull/344))
+
 ## [29.0.1] - 2025-09-08
 ### Fixed
 - [JavaScript] Include schemas in npm package ([#333](https://github.com/cucumber/messages/pull/333))

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -102,6 +102,19 @@
             </plugin>
 
             <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
                 <executions>


### PR DESCRIPTION
This pull request adds OSGi metadata support to the Java package and updates the Maven parent version. The main focus is on improving Java module compatibility with OSGi environments by updating the build configuration.

Java build and packaging improvements:

* Added the `bnd-maven-plugin` to `pom.xml` to generate OSGi metadata, enabling better integration with OSGi-based systems.
* Updated the `maven-jar-plugin` configuration in `pom.xml` to specify the manifest file location, which is necessary for proper OSGi metadata inclusion.
* Bumped the Maven parent version from `4.3.8` to `4.3.9` in `pom.xml` to ensure compatibility with the new plugins and features.

Documentation:

* Updated the `CHANGELOG.md` to document the addition of OSGi metadata for Java.This pull request adds support for OSGi metadata to the Java build, making the project more compatible with OSGi-based environments. The main changes involve updating the Maven build configuration and documenting the addition.

**Build system enhancements:**

* Added the `bnd-maven-plugin` and configured the `maven-jar-plugin` in `pom.xml` to generate OSGi metadata in the build artifacts.
* Updated the parent version in `pom.xml` to `4.3.9-SNAPSHOT` to reflect the ongoing development state.

**Documentation:**

* Noted the addition of OSGi metadata in the `CHANGELOG.md` under the "Added" section.

This results in the following summary:

```
[INFO] The Bundle-SymbolicName is: io.cucumber.messages
[INFO] 29.0.2.SNAPSHOT
[INFO] It has 5 requirements:
[INFO]  ✓ Import-Package: java.io (provided by the JVM)
[INFO]  ✓ Import-Package: java.lang (provided by the JVM)
[INFO]  ✓ Import-Package: java.nio.charset (provided by the JVM)
[INFO]  ✓ Import-Package: java.time (provided by the JVM)
[INFO]  ✓ Import-Package: java.util (provided by the JVM)
[INFO] It provides 2 capabilities:
[INFO]  - Export-Package: io.cucumber.messages; bundle-symbolic-name="io.cucumber.messages"; bundle-version="29.0.2.SNAPSHOT"; version="29.0.2"; uses:="io.cucumber.messages.types"
[INFO]  - Export-Package: io.cucumber.messages.types; bundle-symbolic-name="io.cucumber.messages"; bundle-version="29.0.2.SNAPSHOT"; version="29.0.2"
```

And the final manifest in the jar looks like this:
```
Manifest-Version: 1.0
Created-By: Maven JAR Plugin 3.4.2
Build-Jdk-Spec: 21
Specification-Title: Cucumber Messages
Specification-Version: 29.0
Implementation-Title: Cucumber Messages
Implementation-Version: 29.0.2-SNAPSHOT
Automatic-Module-Name: io.cucumber.messages
Bundle-Description: JSON schema-based messages for Cucumber's inter-proc
 ess communication
Bundle-Developers: cucumber;email="devs@cucumber.io";name="Cucumber Deve
 lopers";organization=Cucumber;organizationUrl="https://github.com/cucum
 ber"
Bundle-DocURL: https://github.com/cucumber/messages
Bundle-License: "MIT License";link="https://www.opensource.org/licenses/
 mit-license"
Bundle-ManifestVersion: 2
Bundle-Name: Cucumber Messages
Bundle-SCM: url="git://github.com/cucumber/messages.git",connection="scm
 :git:git://github.com/cucumber/messages.git",developer-connection="scm:
 git:git@github.com:cucumber/messages.git",tag=HEAD
Bundle-SymbolicName: io.cucumber.messages
Bundle-Version: 29.0.2.SNAPSHOT
Export-Package: io.cucumber.messages;uses:="io.cucumber.messages.types";
 version="29.0.2",io.cucumber.messages.types;version="29.0.2"
Import-Package: java.io,java.lang,java.nio.charset,java.time,java.util
Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
```

@mpkorstanje for me it all looks sane, can you review this?