### PR TITLE
Update protobuf schema for Elixir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Update protobuf schema for Elixir ([#356](https://github.com/cucumber/messages/pull/356))
 
 ## [31.0.0] - 2025-11-18
 ### Added

--- a/elixir/messages.proto
+++ b/elixir/messages.proto
@@ -438,23 +438,25 @@ message Pickle {
   string id = 1;
   // The uri of the source file
   string uri = 2;
+  // The location of this pickle in source file. A pickle constructed from `Examples` will point to the example row.
+  Location location = 3;
   // The name of the pickle
-  string name = 3;
+  string name = 4;
   // The language of the pickle
-  string language = 4;
+  string language = 5;
   // One or more steps
-  repeated PickleStep steps = 5;
+  repeated PickleStep steps = 6;
   /**
    * One or more tags. If this pickle is constructed from a Gherkin document,
    * It includes inherited tags from the `Feature` as well.
    */
-  repeated PickleTag tags = 6;
+  repeated PickleTag tags = 7;
   /**
    * Points to the AST node locations of the pickle. The last one represents the unique
    * id of the pickle. A pickle constructed from `Examples` will have the first
    * id originating from the `Scenario` AST node, and the second from the `TableRow` AST node.
    */
-  repeated string ast_node_ids = 7;
+  repeated string ast_node_ids = 8;
 
   /**
    * A tag


### PR DESCRIPTION
### 🤔 What's changed?

Manually update the protobuf definition in the elixir module so that the published package includes the new Pickle location field from https://github.com/cucumber/messages/pull/308.

### ⚡️ What's your motivation? 

Elixir is still being generated from the protobuf definition per https://github.com/cucumber/messages/issues/63, so changing the JSON schema and regenerating code in https://github.com/cucumber/messages/pull/308 didn't work for Elixir, and this throws up a problem in https://github.com/cucumber/gherkin/pull/433 when trying to make the corresponding Gherkin change. I'll tackle the code generation separately, but this at least gets Elixir to parity right now.

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

I've slotted in the new field before other fields in the order which matches the JSON schema change but is a no-no in protobuf - but I think this is okay because we're only using the protobuf definition to generate code and not to to (de)serialisation of data in the protobuf way.

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
