### PR TITLE
python: Enable uv cache

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install uv and set the python version
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
-          enable-cache: false
+          enable-cache: true
           python-version: ${{ matrix.python-version }}
           version: "0.11.8"
 


### PR DESCRIPTION

### ⚡️ What's your motivation? 

Caches started failing on https://github.com/cucumber/messages/actions/runs/25451151133/job/74668381879. Presumably UV got updated. So I've disabled the cache in 7b9b38fd869578f2d705643167eb6a918986621a. This turns it back on.


### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
