### PR TITLE
[Elixir] Bump otp-version for workflows

### DIFF
--- a/.github/workflows/release-hex.yml
+++ b/.github/workflows/release-hex.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Beam
         uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
         with:
-          otp-version: '27.1'
+          otp-version: '27.3'
           elixir-version: '1.17'
       - name: Install Protoc
         uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0

--- a/.github/workflows/test-elixir.yml
+++ b/.github/workflows/test-elixir.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Beam
         uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
         with:
-          otp-version: '27.1'
+          otp-version: '27.3'
           elixir-version: '1.17'
 
       - run: mix deps.get


### PR DESCRIPTION
### 🤔 What's changed?

Bump the otp-version in our Elixir workflows.

### ⚡️ What's your motivation? 

Gets past erlang/otp#9208 which was causing the release to fail with a TLS error.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
