### PR TITLE
Mark JavaScript package as side-effect free

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - [PHP] Require PHP 8.4
 
+### Fixed
+- [JavaScript] Mark package as side-effect free ([#449](https://github.com/cucumber/messages/pull/449))
+
 ## [33.0.2] - 2026-06-10
 ### Fixed
 - [.Net] Fix release workflow filename ([#443](https://github.com/cucumber/messages/pull/443))

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "sideEffects": false,
   "files": [
     "dist",
     "messages.schema.json"


### PR DESCRIPTION
### 🤔 What's changed?

Added `"sideEffects": false` to the JavaScript package's `package.json`.

### ⚡️ What's your motivation?

`version.ts` exposes the package version like this:

```ts
import { createRequire } from 'node:module'
export const version = createRequire(import.meta.url)('../package.json').version
```

We need to declare no side effects so this can be tree-shaken by bundlers, and not cause errors when targeting browser environments.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
- [ ] My change requires a change to the documentation.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.
