### PR TITLE
[JavaScript] Update static version file at release time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- [JavaScript] Update static version file at release time ([#459](https://github.com/cucumber/messages/pull/459))
 
 ## [33.0.3] - 2026-06-20
 ### Added

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -31,7 +31,8 @@
     "postbuild": "node -e \"require('.')\"",
     "prepare": "make generate",
     "test": "mocha",
-    "prepublishOnly": "npm run build && npm run copy-schemas"
+    "prepublishOnly": "npm run build && npm run copy-schemas",
+    "version": "printf \"export const version = '%s' as string\\n\" \"$npm_package_version\" > src/version.ts"
   },
   "dependencies": {},
   "devDependencies": {

--- a/javascript/src/version.ts
+++ b/javascript/src/version.ts
@@ -1,3 +1,1 @@
-import { createRequire } from 'node:module'
-
-export const version: string = createRequire(import.meta.url)('../package.json').version
+export const version = '33.0.3' as string


### PR DESCRIPTION
### 🤔 What's changed?

Replace the dynamic own-version lookup with a static file that is included in source control and updated automatically as pat of the release process.

### ⚡️ What's your motivation? 

The previous solution worked well but caused issues with browser bundlers due to its use of the `node:module` API. This avoids that while also avoiding a fussy extra build step for contributors.

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
