### PR TITLE
[dart] Add example README pointing to package usage sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 - [Dart] Add initial `cucumber_messages` package with generated message types, NDJSON read/write support, time conversion helpers, and schema validation ([#431](https://github.com/cucumber/messages/pull/431/))
+- [Dart] Add `example/README.md` pointing to the package README usage sections ([#470](https://github.com/cucumber/messages/pull/470))
 
 ### Changed
 - [cpp] Replaced custom cmate script with native cmake and CPM. ([#432](https://github.com/cucumber/messages/pull/432))

--- a/dart/example/README.md
+++ b/dart/example/README.md
@@ -1,0 +1,3 @@
+# Example
+
+See [Reading](../README.md#reading) and [Writing](../README.md#writing).

--- a/dart/example/README.md
+++ b/dart/example/README.md
@@ -1,3 +1,3 @@
 # Example
 
-See [Reading](../README.md#reading) and [Writing](../README.md#writing).
+See [Reading](https://github.com/cucumber/messages/tree/main/dart#reading) and [Writing](https://github.com/cucumber/messages/tree/main/dart#writing).


### PR DESCRIPTION
### 🤔 What's changed?

Added `dart/example/README.md` linking to the package README's [Reading](../README.md#reading) and [Writing](../README.md#writing) sections.

### ⚡️ What's your motivation?

Closes #469: `cucumber_messages` loses 10 pub.dev points for having no example. This satisfies the requirement without adding maintainable code & reusing the README as the source of truth.

### 🏷️ What kind of change is this?

- :book: Documentation (improvements without changing code)

### ♻️ Anything particular you want feedback on?

Whether pointing to README sections is preferred over an intentionally-blank file (per [discussion](https://github.com/cucumber/messages/issues/469#issuecomment-4849228535)).

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*