### PR TITLE
jsonschema: Define minimum and maximum argument index values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Fixed
+- [jsonschema]  Define minimum and maximum argument index values. ([#479](https://github.com/cucumber/messages/pull/479))
 - [cpp] When fetching them is disabled, still try to find them. ([#478](https://github.com/cucumber/messages/pull/478))
 
 ## [34.0.1] - 2026-07-05

--- a/dart/lib/src/generated/pickle_doc_string.g.dart
+++ b/dart/lib/src/generated/pickle_doc_string.g.dart
@@ -6,7 +6,7 @@ part of 'messages.dart';
 
 /// Generated Dart representation of the [PickleDocString message](https://github.com/cucumber/messages/blob/main/jsonschema/src/PickleDocString.schema.json) in Cucumber's [message protocol](https://github.com/cucumber/messages).
 class PickleDocString {
-  /// The `argumentIndex` property.
+  /// The index of this argument. The value is 0 if it was declared before the data table, 1 if it was declared after.
   final int? argumentIndex;
   /// The `mediaType` property.
   final String? mediaType;

--- a/dart/lib/src/generated/pickle_table.g.dart
+++ b/dart/lib/src/generated/pickle_table.g.dart
@@ -6,7 +6,7 @@ part of 'messages.dart';
 
 /// Generated Dart representation of the [PickleTable message](https://github.com/cucumber/messages/blob/main/jsonschema/src/PickleTable.schema.json) in Cucumber's [message protocol](https://github.com/cucumber/messages).
 class PickleTable {
-  /// The `argumentIndex` property.
+  /// The index of this argument. The value is 0 if it was declared before the doc string, 1 if it was declared after.
   final int? argumentIndex;
   /// The `rows` property.
   final List<PickleTableRow> rows;

--- a/dotnet/Cucumber.Messages/generated/PickleDocString.cs
+++ b/dotnet/Cucumber.Messages/generated/PickleDocString.cs
@@ -16,6 +16,9 @@ namespace Io.Cucumber.Messages.Types;
 
 public sealed class PickleDocString 
 {
+    /**
+     * The index of this argument. The value is 0 if it was declared before the data table, 1 if it was declared after.
+     */
     public Nullable<long> ArgumentIndex { get; private set; }
     public string MediaType { get; private set; }
     public string Content { get; private set; }

--- a/dotnet/Cucumber.Messages/generated/PickleTable.cs
+++ b/dotnet/Cucumber.Messages/generated/PickleTable.cs
@@ -16,6 +16,9 @@ namespace Io.Cucumber.Messages.Types;
 
 public sealed class PickleTable 
 {
+    /**
+     * The index of this argument. The value is 0 if it was declared before the doc string, 1 if it was declared after.
+     */
     public Nullable<long> ArgumentIndex { get; private set; }
     public List<PickleTableRow> Rows { get; private set; }
 

--- a/java/src/generated/java/io/cucumber/messages/types/PickleDocString.java
+++ b/java/src/generated/java/io/cucumber/messages/types/PickleDocString.java
@@ -15,12 +15,12 @@ import static java.util.Objects.requireNonNull;
 // Generated code
 @SuppressWarnings({"unused", "JavaLangClash"})
 public final class PickleDocString {
-    private final @Nullable Long argumentIndex;
+    private final @Nullable Integer argumentIndex;
     private final @Nullable String mediaType;
     private final String content;
 
     public PickleDocString(
-        @Nullable @Property("argumentIndex") Long argumentIndex,
+        @Nullable @Property("argumentIndex") Integer argumentIndex,
         @Nullable @Property("mediaType") String mediaType,
         @Property("content") String content
     ) {
@@ -29,7 +29,10 @@ public final class PickleDocString {
         this.content = requireNonNull(content, "PickleDocString.content cannot be null");
     }
 
-    public Optional<Long> getArgumentIndex() {
+    /**
+     * The index of this argument. The value is 0 if it was declared before the data table, 1 if it was declared after.
+     */
+    public Optional<Integer> getArgumentIndex() {
         return Optional.ofNullable(argumentIndex);
     }
 

--- a/java/src/generated/java/io/cucumber/messages/types/PickleTable.java
+++ b/java/src/generated/java/io/cucumber/messages/types/PickleTable.java
@@ -15,18 +15,21 @@ import static java.util.Objects.requireNonNull;
 // Generated code
 @SuppressWarnings({"unused", "JavaLangClash"})
 public final class PickleTable {
-    private final @Nullable Long argumentIndex;
+    private final @Nullable Integer argumentIndex;
     private final List<PickleTableRow> rows;
 
     public PickleTable(
-        @Nullable @Property("argumentIndex") Long argumentIndex,
+        @Nullable @Property("argumentIndex") Integer argumentIndex,
         @Property("rows") List<PickleTableRow> rows
     ) {
         this.argumentIndex = argumentIndex;
         this.rows = List.copyOf(requireNonNull(rows, "PickleTable.rows cannot be null"));
     }
 
-    public Optional<Long> getArgumentIndex() {
+    /**
+     * The index of this argument. The value is 0 if it was declared before the doc string, 1 if it was declared after.
+     */
+    public Optional<Integer> getArgumentIndex() {
         return Optional.ofNullable(argumentIndex);
     }
 

--- a/jsonschema/messages.md
+++ b/jsonschema/messages.md
@@ -1239,7 +1239,7 @@ id originating from the `Scenario` AST node, and the second from the `TableRow` 
 * Type: integer 
 * Required: no 
 
-
+The index of this argument. The value is 0 if it was declared before the data table, 1 if it was declared after.
 
 #### PickleDocString.mediaType 
 
@@ -1324,7 +1324,7 @@ Optional arguments. Either a PickleDocString, PickleTable or both
 * Type: integer 
 * Required: no 
 
-
+The index of this argument. The value is 0 if it was declared before the doc string, 1 if it was declared after.
 
 #### PickleTable.rows 
 

--- a/jsonschema/messages.schema.json
+++ b/jsonschema/messages.schema.json
@@ -996,7 +996,10 @@
           ],
           "properties": {
             "argumentIndex": {
-              "type": "integer"
+              "description": "The index of this argument. The value is 0 if it was declared before the data table, 1 if it was declared after.",
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 1
             },
             "mediaType": {
               "type": "string"
@@ -1069,7 +1072,10 @@
           ],
           "properties": {
             "argumentIndex": {
-              "type": "integer"
+              "description": "The index of this argument. The value is 0 if it was declared before the doc string, 1 if it was declared after.",
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 1
             },
             "rows": {
               "items": {

--- a/jsonschema/src/Pickle.schema.json
+++ b/jsonschema/src/Pickle.schema.json
@@ -10,7 +10,10 @@
       ],
       "properties": {
         "argumentIndex":{
-          "type": "integer"
+          "description": "The index of this argument. The value is 0 if it was declared before the data table, 1 if it was declared after.",
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 1
         },
         "mediaType": {
           "type": "string"
@@ -83,7 +86,10 @@
       ],
       "properties": {
         "argumentIndex":{
-          "type": "integer"
+          "description": "The index of this argument. The value is 0 if it was declared before the doc string, 1 if it was declared after.",
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 1
         },
         "rows": {
           "items": {

--- a/perl/lib/Cucumber/Messages.pm
+++ b/perl/lib/Cucumber/Messages.pm
@@ -2996,7 +2996,7 @@ sub _types {
 
 =head4 argument_index
 
-
+The index of this argument. The value is 0 if it was declared before the data table, 1 if it was declared after.
 =cut
 
 has argument_index =>
@@ -3238,7 +3238,7 @@ sub _types {
 
 =head4 argument_index
 
-
+The index of this argument. The value is 0 if it was declared before the doc string, 1 if it was declared after.
 =cut
 
 has argument_index =>

--- a/php/src-generated/PickleDocString.php
+++ b/php/src-generated/PickleDocString.php
@@ -25,6 +25,10 @@ final class PickleDocString implements JsonSerializable
      *
      */
     public function __construct(
+
+        /**
+         * The index of this argument. The value is 0 if it was declared before the data table, 1 if it was declared after.
+         */
         public readonly ?int $argumentIndex = null,
         public readonly ?string $mediaType = null,
         public readonly string $content = '',

--- a/php/src-generated/PickleTable.php
+++ b/php/src-generated/PickleTable.php
@@ -26,6 +26,10 @@ final class PickleTable implements JsonSerializable
      * @param list<PickleTableRow> $rows
      */
     public function __construct(
+
+        /**
+         * The index of this argument. The value is 0 if it was declared before the doc string, 1 if it was declared after.
+         */
         public readonly ?int $argumentIndex = null,
         public readonly array $rows = [],
     ) {

--- a/python/src/cucumber_messages/_messages.py
+++ b/python/src/cucumber_messages/_messages.py
@@ -438,7 +438,7 @@ class Pickle:
 @dataclass
 class PickleDocString:
     content: str
-    argument_index: Optional[int] = None
+    argument_index: Optional[int] = None  # The index of this argument. The value is 0 if it was declared before the data table, 1 if it was declared after.
     media_type: Optional[str] = None
 
 
@@ -477,7 +477,7 @@ class PickleStepArgument:
 @dataclass
 class PickleTable:
     rows: list[PickleTableRow]
-    argument_index: Optional[int] = None
+    argument_index: Optional[int] = None  # The index of this argument. The value is 0 if it was declared before the doc string, 1 if it was declared after.
 
 
 @dataclass

--- a/ruby/lib/cucumber/messages/pickle_doc_string.rb
+++ b/ruby/lib/cucumber/messages/pickle_doc_string.rb
@@ -8,6 +8,9 @@ module Cucumber
     ##
     ##
     class PickleDocString < Message
+      ##
+      # The index of this argument. The value is 0 if it was declared before the data table, 1 if it was declared after.
+      ##
       attr_reader :argument_index
 
       attr_reader :media_type

--- a/ruby/lib/cucumber/messages/pickle_table.rb
+++ b/ruby/lib/cucumber/messages/pickle_table.rb
@@ -8,6 +8,9 @@ module Cucumber
     ##
     ##
     class PickleTable < Message
+      ##
+      # The index of this argument. The value is 0 if it was declared before the doc string, 1 if it was declared after.
+      ##
       attr_reader :argument_index
 
       attr_reader :rows


### PR DESCRIPTION
### 🤔 What's changed?

Define minimum and maximum argument index values. Because there are at most two arguments, the argument index is only ever 0 or 1. This provides some constraints that that make it easier to implement the logic for ordering arguments.

And frankly, I forgot to add it and didn't notice until Java returned the wrong type for the index. :sweat_smile: 

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.
