### PR TITLE
[cpp] add git-hash to dependencies

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -18,9 +18,6 @@ endif()
 cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
 project(cucumber_messages VERSION ${VERSION} LANGUAGES CXX)
 
-# Required so CMake can find the custom package/config helper modules in ./cmake.
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
-
 # Options
 if (POLICY CMP0077)
     # Allow CMake 3.13+ to override options when using FetchContent / add_subdirectory.
@@ -55,7 +52,7 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
 endif()
 
 # CMake dependencies
-include(dependencies.cpm)
+include(cmake/dependencies.cpm.cmake)
 
 # Target
 set(CUCUMBER_MESSAGES_LIB_INC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/include")

--- a/cpp/cmake/dependencies.cpm.cmake
+++ b/cpp/cmake/dependencies.cpm.cmake
@@ -1,14 +1,21 @@
+# renovate
+set(CPM_DOWNLOAD_VERSION 0.43.1)
 # renovate: datasource=github-tags packageName=nlohmann/json versioning=semver
-set(NLOHMANN_JSON_VERSION 3.12.0 CACHE STRING "Version of nlohmann_json to use")
+set(NLOHMANN_JSON_HASH_VERSION 55f93686c01528224f448c19128836e7df245f72 3.12.0)
 # renovate: datasource=github-tags packageName=google/googletest versioning=semver
-set(GOOGLE_TEST_VERSION 1.17.0 CACHE STRING "Version of googletest to use")
+set(GOOGLE_TEST_HASH_VERSION 52eb8108c5bdec04579160ae17225d66034bd723 1.17.0)
+
+list(GET NLOHMANN_JSON_HASH_VERSION 0 NLOHMANN_JSON_HASH)
+list(GET NLOHMANN_JSON_HASH_VERSION 1 NLOHMANN_JSON_VERSION)
+
+list(GET GOOGLE_TEST_HASH_VERSION 0 GOOGLE_TEST_HASH)
+list(GET GOOGLE_TEST_HASH_VERSION 1 GOOGLE_TEST_VERSION)
 
 if(CUCUMBER_MESSAGES_FETCH_DEPS)
     if(NOT COMMAND CPMAddPackage)
         # ---------------------------------------------------------------------------
         # CPM – download on first configure if not already cached (standalone only)
         # ---------------------------------------------------------------------------
-        set(CPM_DOWNLOAD_VERSION 0.40.2)
         set(CPM_USE_LOCAL_PACKAGES ON)
         set(CPM_DOWNLOAD_LOCATION "${CMAKE_CURRENT_BINARY_DIR}/cmake/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
 
@@ -28,15 +35,12 @@ if(CUCUMBER_MESSAGES_FETCH_DEPS)
     # Dependencies
     # ---------------------------------------------------------------------------
     CPMAddPackage(
+        URI "gh:nlohmann/json@${NLOHMANN_JSON_VERSION}#${NLOHMANN_JSON_HASH}"
         NAME nlohmann_json
-        GITHUB_REPOSITORY nlohmann/json
-        GIT_TAG v${NLOHMANN_JSON_VERSION}
-        OPTIONS "JSON_BuildTests OFF" "JSON_Install ON"
+        OPTIONS
+            "JSON_BuildTests Off"
+            "JSON_Install ON"
     )
-
-    if(TARGET nlohmann_json)
-        set_target_properties(nlohmann_json PROPERTIES SYSTEM ON)
-    endif()
 
     if(nlohmann_json_ADDED)
         # Make the generated config file discoverable by cucumber_messages' find_package()
@@ -44,25 +48,28 @@ if(CUCUMBER_MESSAGES_FETCH_DEPS)
         if(NOT PROJECT_IS_TOP_LEVEL)
             set(CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH}" PARENT_SCOPE)
         endif()
+
+        # Propagate nlohmann_json install rules so 'cmake --install' also installs it
+        install(SCRIPT "${nlohmann_json_BINARY_DIR}/cmake_install.cmake")
     endif()
 
     if (CUCUMBER_MESSAGES_BUILD_TESTS)
         CPMAddPackage(
+            URI "gh:google/googletest@${GOOGLE_TEST_VERSION}#${GOOGLE_TEST_HASH}"
             NAME googletest
-            GITHUB_REPOSITORY google/googletest
-            GIT_TAG v${GOOGLE_TEST_VERSION}
-            OPTIONS "INSTALL_GTEST OFF" "gtest_force_shared_crt ON"
+            OPTIONS
+                "INSTALL_GTEST OFF"
+                "gtest_force_shared_crt ON"
         )
 
         set_target_properties(gtest gtest_main gmock gmock_main PROPERTIES
             FOLDER External/GoogleTest
-            SYSTEM ON
         )
     endif()
 else()
     find_package(nlohmann_json ${NLOHMANN_JSON_VERSION} REQUIRED)
 
     if (CUCUMBER_MESSAGES_BUILD_TESTS)
-        find_package(GTest REQUIRED)
+        find_package(GTest ${GOOGLE_TEST_VERSION} REQUIRED)
     endif()
 endif()


### PR DESCRIPTION
<!---
Thanks for helping to make Cucumber better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻
-->

### 🤔 What's changed?

CPM's AddPackage now uses the git hash of nlohmann/json and google/googletest instead of their version number.

### ⚡️ What's your motivation? 

<!-- 
What motivated you to propose this change? Does it fix a bug? Add a new feature?
If it fixes an open issue, you can link to the issue here, e.g. "Fixes #99"
-->

In general it is better to pin to hash than a git tag since git tags are mutable and hashes are not.

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
