### PR TITLE
[rb] Add required method for time conversion in query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
-- [Ruby] Re-added a new improved `#seconds_to_duration` method using strings to correctly determine floating point amounts. ([#462](https://github.com/cucumber/messages/pull/462))
+- [Ruby] Re-added a new improved `#seconds_to_duration` method using strings to correctly determine floating point amounts. ([#487](https://github.com/cucumber/messages/pull/487))
 
 ## [34.0.2] - 2026-07-13
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- [Ruby] Re-added a new improved `#seconds_to_duration` method using strings to correctly determine floating point amounts. ([#462](https://github.com/cucumber/messages/pull/462))
 
 ## [34.0.2] - 2026-07-13
 ### Added

--- a/ruby/lib/cucumber/messages/helpers/time_conversion.rb
+++ b/ruby/lib/cucumber/messages/helpers/time_conversion.rb
@@ -6,6 +6,12 @@ module Cucumber
       module TimeConversion
         NANOSECONDS_PER_SECOND = 1_000_000_000
 
+        def seconds_to_duration(seconds_float)
+          seconds, decimal = seconds_float.to_s.split('.')
+          nanos = decimal.to_s.ljust(9, '0').to_i
+          { 'seconds' => seconds.to_i, 'nanos' => nanos }
+        end
+
         def time_to_timestamp(time)
           Cucumber::Messages::Timestamp.new(seconds: time.to_i, nanos: time.nsec)
         end

--- a/ruby/spec/cucumber/messages/helpers/time_conversion_spec.rb
+++ b/ruby/spec/cucumber/messages/helpers/time_conversion_spec.rb
@@ -9,6 +9,14 @@ describe Cucumber::Messages::Helpers::TimeConversion do
     end
   end
 
+  describe '#seconds_to_duration' do
+    it 'converts a float value to a hashified number representation of time' do
+      duration = instance.seconds_to_duration(1.234_567)
+
+      expect(duration).to eq({ 'seconds' => 1, 'nanos' => 234_567_000 })
+    end
+  end
+
   describe '#time_to_timestamp' do
     it 'converts a Time to a Timestamp message to Timestamp' do
       timestamp = instance.time_to_timestamp(Time.now)


### PR DESCRIPTION
### 🤔 What's changed?

Back in https://github.com/cucumber/messages/pull/364 I removed / fixed up a few methods. One method I removed was `seconds_to_duration`.

It seems as though as I port more and more of the libraries that are poly, this is more and more used. It was briefly re-added into `core` as the sole single place, but having it in the message helpers would make things readily available

### ⚡️ What's your motivation? 

Allows me to get some code working in query

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :zap: New feature (non-breaking change which adds new behaviour)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
